### PR TITLE
refactor: remove the 'Op' enum

### DIFF
--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -23,7 +23,7 @@ pub(crate) mod unstage;
 
 pub(crate) type Action = Rc<dyn FnMut(&mut State, &mut Term) -> Res<()>>;
 
-pub(crate) trait OpTrait: Display {
+pub(crate) trait OpTrait: Display + PartialEq {
     /// Get the implementation (which may or may not exist) of the Op given some TargetData.
     /// This indirection allows Gitu to show a contextual menu of applicable actions.
     fn get_action(&self, target: Option<&TargetData>) -> Option<Action>;
@@ -33,44 +33,6 @@ pub(crate) trait OpTrait: Display {
     fn is_target_op(&self) -> bool {
         false
     }
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub(crate) enum Op {
-    Quit,
-    Refresh,
-
-    ToggleSection,
-    SelectNext,
-    SelectPrevious,
-    HalfPageUp,
-    HalfPageDown,
-
-    Checkout,
-    CheckoutNewBranch,
-    Commit,
-    CommitAmend,
-    FetchAll,
-    LogCurrent,
-    Pull,
-    Push,
-    RebaseAbort,
-    RebaseContinue,
-    ShowRefs,
-
-    CommitFixup,
-    Discard,
-    LogOther,
-    RebaseAutosquash,
-    RebaseInteractive,
-    ResetSoft,
-    ResetMixed,
-    ResetHard,
-    Show,
-    Stage,
-    Unstage,
-
-    Submenu(SubmenuOp),
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
@@ -87,45 +49,6 @@ pub(crate) enum SubmenuOp {
     Push,
     Rebase,
     Reset,
-}
-
-impl Op {
-    pub fn implementation(self) -> Box<dyn OpTrait> {
-        match self {
-            Op::Quit => Box::new(editor::Quit),
-            Op::Submenu(submenu) => Box::new(editor::Submenu(submenu)),
-            Op::Refresh => Box::new(editor::Refresh),
-            Op::ToggleSection => Box::new(editor::ToggleSection),
-            Op::SelectNext => Box::new(editor::SelectNext),
-            Op::SelectPrevious => Box::new(editor::SelectPrevious),
-            Op::HalfPageUp => Box::new(editor::HalfPageUp),
-            Op::HalfPageDown => Box::new(editor::HalfPageDown),
-
-            Op::Checkout => Box::new(checkout::Checkout),
-            Op::CheckoutNewBranch => Box::new(checkout::CheckoutNewBranch),
-            Op::Commit => Box::new(commit::Commit),
-            Op::CommitAmend => Box::new(commit::CommitAmend),
-            Op::FetchAll => Box::new(fetch::FetchAll),
-            Op::LogCurrent => Box::new(log::LogCurrent),
-            Op::Pull => Box::new(pull::Pull),
-            Op::Push => Box::new(push::Push),
-            Op::RebaseAbort => Box::new(rebase::RebaseAbort),
-            Op::RebaseContinue => Box::new(rebase::RebaseContinue),
-            Op::ShowRefs => Box::new(show_refs::ShowRefs),
-
-            Op::CommitFixup => Box::new(commit::CommitFixup),
-            Op::Discard => Box::new(discard::Discard),
-            Op::LogOther => Box::new(log::LogOther),
-            Op::RebaseAutosquash => Box::new(rebase::RebaseAutosquash),
-            Op::RebaseInteractive => Box::new(rebase::RebaseInteractive),
-            Op::ResetSoft => Box::new(reset::ResetSoft),
-            Op::ResetMixed => Box::new(reset::ResetMixed),
-            Op::ResetHard => Box::new(reset::ResetHard),
-            Op::Show => Box::new(show::Show),
-            Op::Stage => Box::new(stage::Stage),
-            Op::Unstage => Box::new(unstage::Unstage),
-        }
-    }
 }
 
 impl Display for SubmenuOp {


### PR DESCRIPTION
Tried to map directly to trait objects in the src/keybinds.rs module.
This gets rid of the indirection of having an enum of all the `Op`s.

I'm doing something wrong...
```
error[E0391]: cycle detected when computing the inferred outlives predicates for items in this crate
```