### PR TITLE
ci: add cachix workflow

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -1,0 +1,26 @@
+# Publish the Nix flake outputs to Cachix
+name: Cachix
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    name: Publish Flake
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v4
+
+    - name: Install nix
+      uses: cachix/install-nix-action@v26
+
+    - name: Authenticate with Cachix
+      uses: cachix/cachix-action@v14
+      with:
+        name: gitu
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+    - name: Build nix flake
+      run: nix build -L


### PR DESCRIPTION
This adds a binary cache so that Nix users don't have to build gitu on their machine.

For this to work, the repo owner needs to register their project on Cachix and add the secret token to the GitHub repo. Instructions can be found from the official tutorial [here](https://nix.dev/tutorials/nixos/continuous-integration-github-actions):
 
> ### 1. Creating your first binary cache
> 
> It's recommended to have different binary caches per team, depending who will have write/read access to it.
> 
> Fill out the form on the [create binary cache](https://app.cachix.org/cache) page.
> 
> On your freshly created binary cache, follow the **Push binaries** tab instructions.
> 
> ### 2. Setting up secrets
> 
> On your GitHub repository or organization (for use across all repositories):
> 
> 1. Click on `Settings`.
> 2. Click on `Secrets`.
> 3. Add your previously generated secrets (`CACHIX_SIGNING_KEY` and/or `CACHIX_AUTH_TOKEN`).

For this PR, I'm using `CACHIX_AUTH_TOKEN`.
