### PR TITLE
feat: add quit confirmation

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -10,7 +10,19 @@ const DEFAULT_CONFIG: &str = include_str!("default_config.toml");
 
 #[derive(Default, Debug, Deserialize)]
 pub struct Config {
+    pub general: GeneralConfig,
     pub style: StyleConfig,
+}
+
+#[derive(Default, Debug, Deserialize)]
+pub struct GeneralConfig {
+    pub confirm_quit: BoolConfigEntry,
+}
+
+#[derive(Default, Debug, Deserialize)]
+pub struct BoolConfigEntry {
+    #[serde(default)]
+    pub enabled: bool,
 }
 
 #[derive(Default, Debug, Deserialize)]

--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -3,11 +3,6 @@
 # `~/.config/gitu/config.toml`
 
 [general]
-
-# enabled can be either of:
-# - true
-# - false
-
 confirm_quit.enabled = false
 
 [style]

--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -2,6 +2,14 @@
 # It is possible to override settings with an equivalent file at:
 # `~/.config/gitu/config.toml`
 
+[general]
+
+# enabled can be either of:
+# - true
+# - false
+
+confirm_quit.enabled = false
+
 [style]
 # fg / bg can be either of:
 # - a hex value: "#707070"

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -904,3 +904,22 @@ fn inside_submodule() {
     let _state = ctx.init_state_at_path(ctx.dir.child("test-submodule"));
     insta::assert_snapshot!(ctx.redact_buffer());
 }
+
+#[test]
+fn quit_prompt() {
+    let mut ctx = TestContext::setup_init(80, 20);
+
+    let mut state = ctx.init_state();
+    state.update(&mut ctx.term, &[key('q')]).unwrap();
+    insta::assert_snapshot!(ctx.redact_buffer());
+}
+
+#[test]
+fn quit() {
+    let mut ctx = TestContext::setup_init(80, 20);
+
+    // TODO init_state should probably accept `Config` as an arg?
+    let mut state = ctx.init_state();
+    state.update(&mut ctx.term, &[key('q'), key('y')]).unwrap();
+    assert!(state.quit);
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -906,15 +906,6 @@ fn inside_submodule() {
 }
 
 #[test]
-fn quit_prompt() {
-    let mut ctx = TestContext::setup_init(80, 20);
-
-    let mut state = ctx.init_state();
-    state.update(&mut ctx.term, &[key('q')]).unwrap();
-    insta::assert_snapshot!(ctx.redact_buffer());
-}
-
-#[test]
 fn quit() {
     let mut ctx = TestContext::setup_init(80, 20);
 

--- a/tests/snapshots/r#mod__quit_prompt.snap
+++ b/tests/snapshots/r#mod__quit_prompt.snap
@@ -1,0 +1,42 @@
+---
+source: tests/mod.rs
+expression: ctx.redact_buffer()
+---
+Buffer {
+    area: Rect { x: 0, y: 0, width: 80, height: 20 },
+    content: [
+        "🢒No branch                                                                      ",
+        "                                                                                ",
+        " Recent commits                                                                 ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "────────────────────────────────────────────────────────────────────────────────",
+        "? Really quit? (y or n) ›                                                       ",
+    ],
+    styles: [
+        x: 0, y: 0, fg: Reset, bg: Reset, underline: Reset, modifier: BOLD,
+        x: 1, y: 0, fg: Yellow, bg: Reset, underline: Reset, modifier: BOLD,
+        x: 0, y: 1, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
+        x: 1, y: 2, fg: Yellow, bg: Reset, underline: Reset, modifier: NONE,
+        x: 0, y: 3, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
+        x: 0, y: 18, fg: Reset, bg: Reset, underline: Reset, modifier: DIM,
+        x: 0, y: 19, fg: Cyan, bg: Reset, underline: Reset, modifier: NONE,
+        x: 1, y: 19, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
+        x: 2, y: 19, fg: Reset, bg: Reset, underline: Reset, modifier: BOLD,
+        x: 23, y: 19, fg: Cyan, bg: Reset, underline: Reset, modifier: DIM,
+        x: 26, y: 19, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
+    ]
+}


### PR DESCRIPTION
Implements a prompt if the user initiates a quit from the base screen.

```
? Really quit? (y or n) ›
```