### PR TITLE
refactor: better diffing

### DIFF
--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -1,5 +1,12 @@
-use itertools::Itertools;
-use std::{fmt::Display, path::PathBuf};
+use git2::Repository;
+use ratatui::{
+    style::Style,
+    text::{Line, Span, Text},
+};
+use similar::{udiff::UnifiedDiffHunk, Algorithm, ChangeTag, TextDiff};
+use std::{fmt::Display, fs, iter, path::PathBuf, str};
+
+use crate::{config::Config, Res};
 
 #[derive(Debug, Clone)]
 pub(crate) struct Diff {
@@ -21,7 +28,7 @@ pub(crate) struct Hunk {
     pub new_file: PathBuf,
     pub new_start: u32,
     pub header: String,
-    pub content: String,
+    pub content: Text<'static>,
 }
 
 impl Hunk {
@@ -29,27 +36,15 @@ impl Hunk {
         format!("{}{}", &self.file_header, self)
     }
 
-    pub(crate) fn old_content(&self) -> String {
-        self.content
-            .lines()
-            .filter(|line| !line.starts_with('+'))
-            .map(|line| &line[1..])
-            .join("\n")
-    }
-
-    pub(crate) fn new_content(&self) -> String {
-        self.content
-            .lines()
-            .filter(|line| !line.starts_with('-'))
-            .map(|line| &line[1..])
-            .join("\n")
-    }
-
     pub(crate) fn first_diff_line(&self) -> u32 {
         self.content
-            .lines()
+            .lines
+            .iter()
             .enumerate()
-            .filter(|(_, line)| line.starts_with('+') || line.starts_with('-'))
+            .filter(|(_, line)| {
+                let start = &line.spans.first().unwrap().content;
+                start.starts_with('+') || start.starts_with('-')
+            })
             .map(|(i, _)| i)
             .next()
             .unwrap_or(0) as u32
@@ -60,7 +55,154 @@ impl Hunk {
 impl Display for Hunk {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.header)?;
-        f.write_str(&self.content)?;
+        write!(f, "\n{}\n", self.content)?;
         Ok(())
     }
+}
+
+pub(crate) fn convert_diff(
+    config: &Config,
+    repo: &Repository,
+    diff: git2::Diff,
+    workdir: bool,
+) -> Res<Diff> {
+    let mut deltas = vec![];
+
+    diff.print(git2::DiffFormat::PatchHeader, |delta, _maybe_hunk, line| {
+        let line_content = str::from_utf8(line.content()).unwrap();
+        let is_new_header = line_content.starts_with("diff")
+            && line.origin_value() == git2::DiffLineType::FileHeader;
+
+        if is_new_header {
+            let old_content = read_blob(repo, &delta.old_file());
+            let new_content = if workdir {
+                read_workdir(repo, &delta.new_file())
+            } else {
+                read_blob(repo, &delta.new_file())
+            };
+
+            let mut delta = Delta {
+                file_header: line_content.to_string(),
+                old_file: path(&delta.old_file()),
+                new_file: path(&delta.new_file()),
+                hunks: vec![],
+                status: delta.status(),
+            };
+
+            delta.hunks = diff_files(config, &delta, old_content, new_content).unwrap();
+            deltas.push(delta);
+        } else {
+            let delta = deltas.last_mut().unwrap();
+            delta.file_header.push_str(line_content);
+        }
+
+        true
+    })?;
+
+    Ok(Diff { deltas })
+}
+
+fn diff_files(
+    config: &Config,
+    delta: &Delta,
+    old_content: String,
+    new_content: String,
+) -> Res<Vec<Hunk>> {
+    let text_diff = TextDiff::configure()
+        .algorithm(Algorithm::Patience)
+        .diff_lines(&old_content, &new_content);
+
+    Ok(text_diff
+        .unified_diff()
+        .iter_hunks()
+        .map(|hunk| {
+            let formatted_hunk = format_hunk(config, &hunk, &text_diff);
+
+            let new_start = hunk
+                .header()
+                .to_string()
+                .strip_prefix("@@ -")
+                .unwrap()
+                .split(|c| c == ' ' || c == ',')
+                .next()
+                .unwrap()
+                .parse()
+                .unwrap();
+
+            Hunk {
+                file_header: delta.file_header.clone(),
+                new_file: delta.new_file.clone(),
+                new_start,
+                header: format!("{}", hunk.header()),
+                content: formatted_hunk,
+            }
+        })
+        .collect::<Vec<_>>())
+}
+
+fn format_hunk<'diff, 'old, 'new, 'bufs>(
+    config: &Config,
+    hunk: &UnifiedDiffHunk<'diff, 'old, 'new, 'bufs, str>,
+    text_diff: &'diff TextDiff<'old, 'new, 'bufs, str>,
+) -> Text<'static>
+where
+    'diff: 'old + 'new,
+{
+    let formatted_hunk = hunk.ops().iter().flat_map(|op| {
+        text_diff
+            .iter_inline_changes(op)
+            .map(|change| format_line_change(config, &change))
+    });
+
+    formatted_hunk.collect::<Vec<_>>().into()
+}
+
+fn format_line_change(config: &Config, change: &similar::InlineChange<str>) -> Line<'static> {
+    let style = &config.style;
+
+    let line_style = match change.tag() {
+        ChangeTag::Equal => Style::new(),
+        ChangeTag::Delete => (&style.line_removed).into(),
+        ChangeTag::Insert => (&style.line_added).into(),
+    };
+
+    let some_emph = change.iter_strings_lossy().any(|(emph, _value)| emph);
+
+    let spans = iter::once(Span::styled(format!("{}", change.tag()), line_style))
+        .chain(change.iter_strings_lossy().map(|(emph, value)| {
+            Span::styled(
+                value.trim_end_matches('\n').to_string(),
+                if some_emph {
+                    if emph {
+                        line_style.patch(&style.line_highlight.changed)
+                    } else {
+                        line_style.patch(&style.line_highlight.unchanged)
+                    }
+                } else {
+                    line_style
+                },
+            )
+        }))
+        .collect::<Vec<_>>();
+
+    Line::from(spans)
+}
+
+fn read_workdir(repo: &Repository, new_file: &git2::DiffFile<'_>) -> String {
+    fs::read_to_string(
+        repo.workdir()
+            .expect("No workdir")
+            .join(new_file.path().unwrap()),
+    )
+    .unwrap()
+}
+
+fn read_blob(repo: &Repository, file: &git2::DiffFile<'_>) -> String {
+    let blob = repo.find_blob(file.id());
+    blob.map(|blob| String::from_utf8(blob.content().to_vec()).unwrap())
+        .unwrap_or("".to_string())
+}
+
+fn path(file: &git2::DiffFile) -> PathBuf {
+    file.path().unwrap().to_path_buf()
 }

--- a/src/screen/show.rs
+++ b/src/screen/show.rs
@@ -26,7 +26,7 @@ pub(crate) fn create(
         Box::new(move || {
             let style = &config.style;
             let commit = git::show_summary(repo.as_ref(), &reference)?;
-            let show = git::show(repo.as_ref(), &reference)?;
+            let show = git::show(&config, repo.as_ref(), &reference)?;
             let details = Text::from(commit.details).lines;
 
             Ok(iter::once(Item {

--- a/src/screen/status.rs
+++ b/src/screen/status.rs
@@ -94,13 +94,13 @@ pub(crate) fn create(config: Rc<Config>, repo: Rc<Repository>, size: Rect) -> Re
                 Rc::clone(&config),
                 "Unstaged changes",
                 Some(TargetData::AllUnstaged),
-                &git::diff_unstaged(repo.as_ref())?,
+                &git::diff_unstaged(&config, repo.as_ref())?,
             ))
             .chain(create_status_section_items(
                 Rc::clone(&config),
                 "Staged changes",
                 Some(TargetData::AllStaged),
-                &git::diff_staged(repo.as_ref())?,
+                &git::diff_staged(&config, repo.as_ref())?,
             ))
             .chain(create_log_section_items(
                 Rc::clone(&config),


### PR DESCRIPTION
'Hunk' now stores formatted 'Text'.

There was an issue where what was shown and translated into lines on the screen was the result of a
second diff between Hunks done by the 'similar' lib.

Now instead, 'similar' diffs entire files,
which makes it easier to correlate about what is
shown on screen, and what is being included in
a patch.

Moreover, this will make it easier to
apply code syntax-highlighting within diffs.