### PR TITLE
fix: stash working tree should work when everything/nothing is staged

### DIFF
--- a/src/ops/stash.rs
+++ b/src/ops/stash.rs
@@ -1,8 +1,12 @@
 use super::{Action, OpTrait};
-use crate::{items::TargetData, prompt::PromptData, state::State, term::Term, Res};
+use crate::{items::TargetData, prompt::PromptData, state::State, term::Term, CmdLogEntry, Res};
 use derive_more::Display;
 use git2::{Repository, Status, StatusOptions};
-use std::{process::Command, rc::Rc};
+use std::{
+    process::Command,
+    rc::Rc,
+    sync::{Arc, RwLock},
+};
 use tui_prompts::State as _;
 
 pub(crate) fn args() -> &'static [(&'static str, bool)] {
@@ -64,12 +68,18 @@ impl OpTrait for StashWorktree {
         Some(Rc::new(
             move |state: &mut State, _term: &mut Term| -> Res<()> {
                 if is_working_tree_empty(&state.repo)? {
+                    state
+                        .current_cmd_log_entries
+                        .push(Arc::new(RwLock::new(CmdLogEntry::Error(
+                            "Cannot stash: working tree is empty".to_string(),
+                        ))));
                     return Ok(());
                 }
-                Ok(state.prompt.set(PromptData {
+                state.prompt.set(PromptData {
                     prompt_text: "Name of the stash:".into(),
                     update_fn: Rc::new(update_fn),
-                }))
+                });
+                Ok(())
             },
         ))
     }

--- a/src/ops/stash.rs
+++ b/src/ops/stash.rs
@@ -34,10 +34,6 @@ impl OpTrait for StashWorktree {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
         let update_fn = move |state: &mut State, term: &mut Term| -> Res<()> {
             if state.prompt.state.status().is_done() {
-                if is_working_tree_empty(&state.repo)? {
-                    state.prompt.reset(term)?;
-                    return Ok(());
-                }
                 let input = state.prompt.state.value().to_string();
                 state.prompt.reset(term)?;
 
@@ -67,11 +63,13 @@ impl OpTrait for StashWorktree {
 
         Some(Rc::new(
             move |state: &mut State, _term: &mut Term| -> Res<()> {
-                state.prompt.set(PromptData {
+                if is_working_tree_empty(&state.repo)? {
+                    return Ok(());
+                }
+                Ok(state.prompt.set(PromptData {
                     prompt_text: "Name of the stash:".into(),
                     update_fn: Rc::new(update_fn),
-                });
-                Ok(())
+                }))
             },
         ))
     }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -487,21 +487,44 @@ mod stash {
     }
 
     #[test]
-    pub(crate) fn stash_working_tree_then_index_and_then_pop() {
+    pub(crate) fn stash_working_tree_when_everything_is_staged() {
         let (mut ctx, mut state) = setup();
         state
             .update(
                 &mut ctx.term,
                 &[
+                    key('j'),
+                    key('s'),
                     key('z'),
                     key('w'),
+                    key('t'),
+                    key('e'),
+                    key('s'),
+                    key('t'),
                     key_code(KeyCode::Enter),
+                ],
+            )
+            .unwrap();
+        insta::assert_snapshot!(ctx.redact_buffer());
+    }
+
+    #[test]
+    pub(crate) fn stash_working_tree_when_nothing_is_staged() {
+        let (mut ctx, mut state) = setup();
+        state
+            .update(
+                &mut ctx.term,
+                &[
+                    key('j'),
+                    key('j'),
+                    key('j'),
+                    key('u'),
                     key('z'),
-                    key('i'),
-                    key_code(KeyCode::Enter),
-                    key('z'),
-                    key('p'),
-                    key('1'),
+                    key('w'),
+                    key('t'),
+                    key('e'),
+                    key('s'),
+                    key('t'),
                     key_code(KeyCode::Enter),
                 ],
             )

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -490,20 +490,7 @@ mod stash {
     pub(crate) fn stash_working_tree_when_everything_is_staged() {
         let (mut ctx, mut state) = setup();
         state
-            .update(
-                &mut ctx.term,
-                &[
-                    key('j'),
-                    key('s'),
-                    key('z'),
-                    key('w'),
-                    key('t'),
-                    key('e'),
-                    key('s'),
-                    key('t'),
-                    key_code(KeyCode::Enter),
-                ],
-            )
+            .update(&mut ctx.term, &[key('j'), key('s'), key('z'), key('w')])
             .unwrap();
         insta::assert_snapshot!(ctx.redact_buffer());
     }

--- a/src/tests/snapshots/gitu__tests__stash__stash_working_tree_when_everything_is_staged.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_working_tree_when_everything_is_staged.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/mod.rs
+expression: ctx.redact_buffer()
+---
+ On branch main                                                                 |
+ Your branch is up to date with 'origin/main'.                                  |
+                                                                                |
+▌Staged changes (2)                                                             |
+▌added   file-one…                                                              |
+▌added   file-two                                                               |
+▌@@ -0,0 +1 @@                                                                  |
+▌+blahonga                                                                      |
+                                                                                |
+ Recent commits                                                                 |
+ _______ main origin/main add initial-file                                      |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: 7c1d9944e66300a6

--- a/src/tests/snapshots/gitu__tests__stash__stash_working_tree_when_everything_is_staged.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_working_tree_when_everything_is_staged.snap
@@ -20,6 +20,6 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
-                                                                                |
-                                                                                |
-styles_hash: 7c1d9944e66300a6
+────────────────────────────────────────────────────────────────────────────────|
+! Cannot stash: working tree is empty                                           |
+styles_hash: e729373ba41fd709

--- a/src/tests/snapshots/gitu__tests__stash__stash_working_tree_when_nothing_is_staged.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_working_tree_when_nothing_is_staged.snap
@@ -1,18 +1,19 @@
 ---
 source: src/tests/mod.rs
+assertion_line: 532
 expression: ctx.redact_buffer()
 ---
-▌On branch main                                                                 |
-▌Your branch is up to date with 'origin/main'.                                  |
-                                                                                |
- Untracked files                                                                |
- file-two                                                                       |
+ On branch main                                                                 |
+ Your branch is up to date with 'origin/main'.                                  |
                                                                                 |
  Stashes                                                                        |
- stash@0 WIP on main: _______ add initial-file                                  |
+ stash@0 On main: test                                                          |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+▌_______ main origin/main add initial-file                                      |
+                                                                                |
+                                                                                |
+                                                                                |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -21,5 +22,5 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-$ git stash pop 1                                                               |
-styles_hash: 1051e7e46b0801a2
+$ git stash push --include-untracked --message test                             |
+styles_hash: a5aaa93bdd9a3cbd


### PR DESCRIPTION
Stash working tree is running 3 commands so there is some edge cases which we should take into account:
1. If everything is staged don't do anything
2. If nothing is staged don't try to save index in the stash and then later pop it (either errors or pops non-related stashes)

Addresses: https://github.com/altsem/gitu/pull/100#issuecomment-2025832482