### PR TITLE
fix: improve error-handling of external commands

### DIFF
--- a/src/ops/checkout.rs
+++ b/src/ops/checkout.rs
@@ -43,11 +43,11 @@ impl OpTrait for CheckoutNewBranch {
 fn checkout_new_branch_prompt_update(state: &mut State, term: &mut Term) -> Res<()> {
     if state.prompt.state.status().is_done() {
         let name = state.prompt.state.value().to_string();
+        state.prompt.reset(term)?;
+
         let mut cmd = Command::new("git");
         cmd.args(["checkout", "-b", &name]);
-
         state.run_cmd(term, &[], cmd)?;
-        state.prompt.reset(term)?;
     }
     Ok(())
 }

--- a/src/ops/log.rs
+++ b/src/ops/log.rs
@@ -1,5 +1,5 @@
 use super::{create_rev_prompt, Action, OpTrait};
-use crate::{items::TargetData, screen, state::State, term::Term, ErrorBuffer, Res};
+use crate::{items::TargetData, screen, state::State, term::Term, Res};
 use derive_more::Display;
 use git2::Oid;
 use std::rc::Rc;
@@ -31,13 +31,9 @@ impl OpTrait for LogOther {
 
 fn log_other(state: &mut State, _term: &mut Term, result: &str) -> Res<()> {
     let oid = match state.repo.revparse_single(result) {
-        Ok(rev) => rev.id(),
-        Err(err) => {
-            state.error_buffer = Some(ErrorBuffer(format!("Failed due to: {:?}", err.code())));
-            // TODO Don't return Ok here. Let it be handled at a higher level
-            return Ok(());
-        }
-    };
+        Ok(rev) => Ok(rev.id()),
+        Err(err) => Err(format!("Failed due to: {:?}", err.code())),
+    }?;
 
     goto_log_screen(state, Some(oid));
     Ok(())

--- a/src/ops/stash.rs
+++ b/src/ops/stash.rs
@@ -34,6 +34,7 @@ impl OpTrait for StashWorktree {
         let update_fn = move |state: &mut State, term: &mut Term| -> Res<()> {
             if state.prompt.state.status().is_done() {
                 let input = state.prompt.state.value().to_string();
+                state.prompt.reset(term)?;
 
                 // 1. Stash index (stash@0: index, ...)
                 let mut cmd = Command::new("git");
@@ -52,8 +53,6 @@ impl OpTrait for StashWorktree {
                 let mut cmd = Command::new("git");
                 cmd.args(["stash", "pop", "1"]);
                 state.run_cmd(term, &[], cmd)?;
-
-                state.prompt.reset(term)?;
             }
             Ok(())
         };
@@ -95,6 +94,7 @@ fn stash_push_action_prompt_update<const N: usize>(
     move |state: &mut State, term: &mut Term| -> Res<()> {
         if state.prompt.state.status().is_done() {
             let input = state.prompt.state.value().to_string();
+            state.prompt.reset(term)?;
 
             let mut cmd = Command::new("git");
             cmd.args(["stash", "push"]);
@@ -104,7 +104,6 @@ fn stash_push_action_prompt_update<const N: usize>(
             }
 
             state.run_cmd(term, &[], cmd)?;
-            state.prompt.reset(term)?;
         }
         Ok(())
     }
@@ -159,6 +158,8 @@ fn stash_target_action_prompt_update(
     |state: &mut State, term: &mut Term| -> Res<()> {
         if state.prompt.state.status().is_done() {
             let input = state.prompt.state.value().to_string();
+            state.prompt.reset(term)?;
+
             let stash_id: usize = match (input.parse(), default_target_stash(state)) {
                 (Err(_), None) => 0,
                 (Err(_), Some(default)) => default,
@@ -169,7 +170,6 @@ fn stash_target_action_prompt_update(
             cmd.args(["stash", command, stash_id.to_string().as_str()]);
 
             state.run_cmd(term, &[], cmd)?;
-            state.prompt.reset(term)?;
         }
         Ok(())
     }

--- a/src/tests/snapshots/gitu__tests__discard__discard_branch_no.snap
+++ b/src/tests/snapshots/gitu__tests__discard__discard_branch_no.snap
@@ -11,5 +11,5 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-Aborted                                                                         |
-styles_hash: 15995b30d609d81f
+! Aborted                                                                       |
+styles_hash: 504879f0f4947fda

--- a/src/tests/snapshots/gitu__tests__log__log_other_invalid.snap
+++ b/src/tests/snapshots/gitu__tests__log__log_other_invalid.snap
@@ -21,5 +21,5 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-Failed due to: InvalidSpec                                                      |
-styles_hash: 4021e85ffca94520
+! Failed due to: InvalidSpec                                                    |
+styles_hash: a2ec62a8d607c12b


### PR DESCRIPTION
- Combine 'CmdLogEntry' and 'ErrorBuffer'
- Ability to show multiple errors for multiple successive failed commands
- Break execution if 'run_cmd' or 'run_cmd_interactive' don't return 0

![image](https://github.com/altsem/gitu/assets/3618477/2aef8a0f-e069-47eb-a8c0-4ef02eefc279)
