### PR TITLE
Feat/non blocking

### DIFF
--- a/src/ops/fetch.rs
+++ b/src/ops/fetch.rs
@@ -16,7 +16,7 @@ impl OpTrait for FetchAll {
             let mut cmd = Command::new("git");
             cmd.args(["fetch", "--all"]);
 
-            state.run_cmd(term, &[], cmd)?;
+            state.run_cmd_async(term, &[], cmd)?;
             Ok(())
         }))
     }

--- a/src/ops/pull.rs
+++ b/src/ops/pull.rs
@@ -16,7 +16,7 @@ impl OpTrait for Pull {
             let mut cmd = Command::new("git");
             cmd.args(["pull"]);
 
-            state.run_cmd(term, &[], cmd)?;
+            state.run_cmd_async(term, &[], cmd)?;
             Ok(())
         }))
     }

--- a/src/ops/push.rs
+++ b/src/ops/push.rs
@@ -17,7 +17,7 @@ impl OpTrait for Push {
             cmd.args(["push"]);
             cmd.args(state.pending_menu.as_ref().unwrap().args());
 
-            state.run_cmd(term, &[], cmd)?;
+            state.run_cmd_async(term, &[], cmd)?;
             Ok(())
         }))
     }

--- a/src/tests/helpers/ui.rs
+++ b/src/tests/helpers/ui.rs
@@ -57,10 +57,12 @@ impl TestContext {
             self.size,
             &Args::default(),
             config::init_test_config().unwrap(),
+            false,
         )
         .unwrap();
 
-        state.update(&mut self.term, &[]).unwrap();
+        // hack: Pass in an event just to force re-rendering
+        state.update(&mut self.term, &[Event::FocusGained]).unwrap();
         state
     }
 

--- a/src/tests/snapshots/gitu__tests__discard__discard_branch_yes.snap
+++ b/src/tests/snapshots/gitu__tests__discard__discard_branch_yes.snap
@@ -9,7 +9,7 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git branch -d asd                                                             |
-                                                                                |
-styles_hash: 1396152e0c770793
+styles_hash: 81e21259cce6741e

--- a/src/tests/snapshots/gitu__tests__discard__discard_staged_file.snap
+++ b/src/tests/snapshots/gitu__tests__discard__discard_staged_file.snap
@@ -9,7 +9,7 @@ expression: ctx.redact_buffer()
 ▌_______ main add file-one                                                      |
  _______ origin/main add initial-file                                           |
                                                                                 |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git checkout HEAD -- file-one                                                 |
-                                                                                |
-styles_hash: 3443e97838d7c625
+styles_hash: a3f19b2153c6a71

--- a/src/tests/snapshots/gitu__tests__discard__discard_unstaged_delta.snap
+++ b/src/tests/snapshots/gitu__tests__discard__discard_unstaged_delta.snap
@@ -9,7 +9,7 @@ expression: ctx.redact_buffer()
 ▌_______ main add file-one                                                      |
  _______ origin/main add initial-file                                           |
                                                                                 |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git checkout HEAD -- file-one                                                 |
-                                                                                |
-styles_hash: 3443e97838d7c625
+styles_hash: a3f19b2153c6a71

--- a/src/tests/snapshots/gitu__tests__discard__discard_unstaged_hunk.snap
+++ b/src/tests/snapshots/gitu__tests__discard__discard_unstaged_hunk.snap
@@ -9,7 +9,7 @@ expression: ctx.redact_buffer()
 ▌_______ origin/main add initial-file                                           |
                                                                                 |
                                                                                 |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git apply --reverse                                                           |
-                                                                                |
-styles_hash: b7434e430a720897
+styles_hash: 3e2e2a3262567be4

--- a/src/tests/snapshots/gitu__tests__rebase__rebase_elsewhere.snap
+++ b/src/tests/snapshots/gitu__tests__rebase__rebase_elsewhere.snap
@@ -19,7 +19,7 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git rebase main                                                               |
-                                                                                |
-styles_hash: 66509308af71a94c
+styles_hash: 6daa3533e8314a9e

--- a/src/tests/snapshots/gitu__tests__stage__stage_added_line.snap
+++ b/src/tests/snapshots/gitu__tests__stage__stage_added_line.snap
@@ -19,7 +19,7 @@ expression: ctx.redact_buffer()
   testtest                                                                      |
  +weehooo                                                                       |
                                                                                 |
+ Recent commits                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git apply --cached --recount                                                  |
-                                                                                |
-styles_hash: 245e62315e91d807
+styles_hash: d7cb47a328ccffa7

--- a/src/tests/snapshots/gitu__tests__stage__stage_all_unstaged.snap
+++ b/src/tests/snapshots/gitu__tests__stage__stage_all_unstaged.snap
@@ -19,7 +19,7 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git add -u .                                                                  |
-                                                                                |
-styles_hash: 578c69ac5f3fad82
+styles_hash: da5cd136a9bf8912

--- a/src/tests/snapshots/gitu__tests__stage__stage_all_untracked.snap
+++ b/src/tests/snapshots/gitu__tests__stage__stage_all_untracked.snap
@@ -19,7 +19,7 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git add file-a file-b                                                         |
-                                                                                |
-styles_hash: eb0fe93ebd344926
+styles_hash: 8de03ccd9895ecb7

--- a/src/tests/snapshots/gitu__tests__stage__stage_removed_line.snap
+++ b/src/tests/snapshots/gitu__tests__stage__stage_removed_line.snap
@@ -19,7 +19,7 @@ expression: ctx.redact_buffer()
                                                                                 |
  Recent commits                                                                 |
  _______ main add firstfile                                                     |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git apply --cached --recount                                                  |
-                                                                                |
-styles_hash: 47aa7c5458240429
+styles_hash: be9d3fbe3835322c

--- a/src/tests/snapshots/gitu__tests__stage_last_hunk_of_first_delta.snap
+++ b/src/tests/snapshots/gitu__tests__stage_last_hunk_of_first_delta.snap
@@ -19,7 +19,7 @@ expression: ctx.redact_buffer()
  _______ add file-one                                                           |
  _______ origin/main add initial-file                                           |
                                                                                 |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git apply --cached                                                            |
-                                                                                |
-styles_hash: 3974ddc8dcf079d7
+styles_hash: d68295efec82de5f

--- a/src/tests/snapshots/gitu__tests__stash__stash.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash.snap
@@ -19,7 +19,7 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git stash push --include-untracked --message test                             |
-                                                                                |
-styles_hash: a21f2b277eae9406
+styles_hash: 3cf025e810662146

--- a/src/tests/snapshots/gitu__tests__stash__stash_apply.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_apply.snap
@@ -19,7 +19,7 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git stash apply 1                                                             |
-                                                                                |
-styles_hash: c89c80fa6f4ed00e
+styles_hash: eb5fa8bafe1ab854

--- a/src/tests/snapshots/gitu__tests__stash__stash_apply_default.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_apply_default.snap
@@ -19,7 +19,7 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git stash apply 0                                                             |
-                                                                                |
-styles_hash: f7dee4b74336ec13
+styles_hash: ad4552bb144bc8ec

--- a/src/tests/snapshots/gitu__tests__stash__stash_drop.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_drop.snap
@@ -19,7 +19,7 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git stash drop 1                                                              |
-                                                                                |
-styles_hash: dfd2a495b8602e3f
+styles_hash: e021cbe37549785a

--- a/src/tests/snapshots/gitu__tests__stash__stash_drop_default.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_drop_default.snap
@@ -19,7 +19,7 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git stash drop 0                                                              |
-                                                                                |
-styles_hash: dfd2a495b8602e3f
+styles_hash: e021cbe37549785a

--- a/src/tests/snapshots/gitu__tests__stash__stash_index.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_index.snap
@@ -19,7 +19,7 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git stash push --staged --message test                                        |
-                                                                                |
-styles_hash: 1d8668271ca8912a
+styles_hash: b2397ce341055fe3

--- a/src/tests/snapshots/gitu__tests__stash__stash_keeping_index.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_keeping_index.snap
@@ -19,7 +19,7 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git stash push --keep-index --include-untracked --message test                |
-                                                                                |
-styles_hash: 47b6f234256a56ab
+styles_hash: 496a7a1678ed9b44

--- a/src/tests/snapshots/gitu__tests__stash__stash_pop.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_pop.snap
@@ -19,7 +19,7 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git stash pop 1                                                               |
-                                                                                |
-styles_hash: a77b409cef95669e
+styles_hash: ed1d8470a3b89318

--- a/src/tests/snapshots/gitu__tests__stash__stash_pop_default.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_pop_default.snap
@@ -19,7 +19,7 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git stash pop 0                                                               |
-                                                                                |
-styles_hash: 4d1c2cbbf36ff211
+styles_hash: 1051e7e46b0801a2

--- a/src/tests/snapshots/gitu__tests__stash__stash_working_tree.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_working_tree.snap
@@ -15,11 +15,11 @@ expression: ctx.redact_buffer()
  _______ main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
+                                                                                |
+                                                                                |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git stash push --staged                                                       |
-                                                                                |
 $ git stash push --include-untracked --message test                             |
-                                                                                |
 $ git stash pop 1                                                               |
-                                                                                |
-styles_hash: efc13709fc47701b
+styles_hash: 276caf6db4468d52

--- a/src/tests/snapshots/gitu__tests__stash__stash_working_tree_then_index_and_then_pop.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_working_tree_then_index_and_then_pop.snap
@@ -19,7 +19,7 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git stash pop 1                                                               |
-                                                                                |
-styles_hash: 4d1c2cbbf36ff211
+styles_hash: 1051e7e46b0801a2

--- a/src/tests/snapshots/gitu__tests__unstage__unstage_added_line.snap
+++ b/src/tests/snapshots/gitu__tests__unstage__unstage_added_line.snap
@@ -19,7 +19,7 @@ expression: ctx.redact_buffer()
                                                                                 |
  Recent commits                                                                 |
  _______ main add firstfile                                                     |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git apply --cached --reverse --recount                                        |
-                                                                                |
-styles_hash: 6129dd8d213084af
+styles_hash: fc37b34b929c904c

--- a/src/tests/snapshots/gitu__tests__unstage__unstage_all_staged.snap
+++ b/src/tests/snapshots/gitu__tests__unstage__unstage_all_staged.snap
@@ -19,7 +19,7 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git reset HEAD --                                                             |
-                                                                                |
-styles_hash: 1e37dbcf2d9ecc04
+styles_hash: d392b4980ef581b2

--- a/src/tests/snapshots/gitu__tests__unstage__unstage_removed_line.snap
+++ b/src/tests/snapshots/gitu__tests__unstage__unstage_removed_line.snap
@@ -19,7 +19,7 @@ expression: ctx.redact_buffer()
  +weehooo                                                                       |
  +blrergh                                                                       |
                                                                                 |
+ Recent commits                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git apply --cached --reverse --recount                                        |
-                                                                                |
-styles_hash: c4fba1d39978c6e7
+styles_hash: 6847c43f05d43e7

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,3 +1,6 @@
+use std::sync::Arc;
+use std::sync::RwLock;
+
 use crate::config::Config;
 use crate::items::Item;
 use crate::keybinds;
@@ -15,39 +18,39 @@ use ratatui::Frame;
 use tui_prompts::State as _;
 use tui_prompts::TextPrompt;
 
-enum Popup<'a> {
-    None,
-    Paragraph(Paragraph<'a>),
-    Table(Table<'a>),
-}
-
 pub(crate) fn ui(frame: &mut Frame, state: &mut State) {
-    let (popup_line_count, popup): (usize, Popup) = if !state.current_cmd_log_entries.is_empty() {
-        let text: Text = state
-            .current_cmd_log_entries
-            .iter()
-            .flat_map(|cmd| format_command(&state.config, cmd))
-            .collect::<Vec<_>>()
-            .into();
+    let (log_len, maybe_log): (usize, Option<Paragraph>) =
+        if !state.current_cmd_log_entries.is_empty() {
+            let text: Text = state
+                .current_cmd_log_entries
+                .iter()
+                .flat_map(|cmd| format_command(&state.config, cmd))
+                .collect::<Vec<_>>()
+                .into();
 
-        (text.lines.len(), command_popup(text))
-    } else if let Some(ref menu) = state.pending_menu {
-        format_keybinds_menu(&state.config, menu, state.screen().get_selected_item())
+            (
+                text.lines.len() + 1,
+                Some(Paragraph::new(text).block(popup_block())),
+            )
+        } else {
+            (0, None)
+        };
+
+    let (menu_len, maybe_menu) = if let Some(ref menu) = state.pending_menu {
+        let (lines, table) =
+            format_keybinds_menu(&state.config, menu, state.screen().get_selected_item());
+
+        (lines + 1, Some(table.block(popup_block())))
     } else {
-        (0, Popup::None)
+        (0, None)
     };
-
-    let popup_len = if popup_line_count > 0 {
-        popup_line_count + 1
-    } else {
-        0
-    } as u16;
 
     let layout = Layout::new(
         Direction::Vertical,
         [
             Constraint::Min(1),
-            Constraint::Length(popup_len),
+            Constraint::Length(log_len as u16),
+            Constraint::Length(menu_len as u16),
             Constraint::Length(if state.prompt.data.is_some() { 2 } else { 0 }),
         ],
     )
@@ -55,22 +58,23 @@ pub(crate) fn ui(frame: &mut Frame, state: &mut State) {
 
     frame.render_widget(state.screen(), layout[0]);
 
-    match popup {
-        Popup::None => (),
-        Popup::Paragraph(paragraph) => frame.render_widget(paragraph, layout[1]),
-        Popup::Table(table) => frame.render_widget(table, layout[1]),
+    if let Some(log) = maybe_log {
+        frame.render_widget(log, layout[1]);
+    }
+    if let Some(menu) = maybe_menu {
+        frame.render_widget(menu, layout[2]);
     }
 
     if let Some(prompt_data) = &state.prompt.data {
         let prompt = TextPrompt::new(prompt_data.prompt_text.clone()).with_block(popup_block());
-        frame.render_stateful_widget(prompt, layout[2], &mut state.prompt.state);
+        frame.render_stateful_widget(prompt, layout[3], &mut state.prompt.state);
         let (cx, cy) = state.prompt.state.cursor();
         frame.set_cursor(cx, cy);
     }
 }
 
-fn format_command<'a>(config: &Config, log: &'a CmdLogEntry) -> Vec<Line<'a>> {
-    match log {
+fn format_command<'a>(config: &Config, log: &Arc<RwLock<CmdLogEntry>>) -> Vec<Line<'a>> {
+    match &*log.read().unwrap() {
         CmdLogEntry::Cmd { args, out } => [Line::styled(
             format!("$ {}{}", args, if out.is_some() { "" } else { "..." }),
             &config.style.command,
@@ -91,7 +95,7 @@ fn format_keybinds_menu<'b>(
     config: &Config,
     pending: &'b PendingMenu,
     item: &'b Item,
-) -> (usize, Popup<'b>) {
+) -> (usize, Table<'b>) {
     let style = &config.style;
 
     let arg_binds = keybinds::arg_list(&pending.menu).collect::<Vec<_>>();
@@ -209,14 +213,8 @@ fn format_keybinds_menu<'b>(
         Constraint::Max(12),
         Constraint::Length(30),
     ];
-    (
-        rows.len(),
-        Popup::Table(Table::new(rows, widths).block(popup_block())),
-    )
-}
 
-fn command_popup(text: Text<'_>) -> Popup {
-    Popup::Paragraph(Paragraph::new(text).block(popup_block()))
+    (rows.len(), Table::new(rows, widths))
 }
 
 fn popup_block() -> Block<'static> {


### PR DESCRIPTION
closes: #97

Now fetch/pull/push can run async. Still only one git command (non-reads) can be run at a time. The popup will linger as long as its running, and show on-top of any menu too.

Running fetch as well as viewing the log menu:
![image](https://github.com/altsem/gitu/assets/3618477/1b5ae7c6-445c-4750-bb46-bee6e0f05106)

Attempting to run a second `git fetch --all`:
![image](https://github.com/altsem/gitu/assets/3618477/ee8078cb-e091-4ec3-8b82-96effe4bc364)
