### PR TITLE
fix: redraw screen even if command failed

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -285,9 +285,9 @@ impl State {
 
         let result = write_child_output_to_log(log_rwlock, child, status);
         self.pending_cmd = None;
+        self.screen_mut().update()?;
         result?;
 
-        self.screen_mut().update()?;
         Ok(true)
     }
 


### PR DESCRIPTION
fix: https://github.com/altsem/gitu/issues/113
I still trying to figure out how to do not left garbage in the stash without crutches... Any ideas are welcome!

refs: https://github.com/altsem/gitu/pull/103#issuecomment-2027478578, https://github.com/altsem/gitu/pull/73#discussion_r1527529800, https://github.com/magit/magit/blob/a334412159984dcdcff3dbb56c7c1e77197cc36c/lisp/magit-stash.el#L150, https://github.com/magit/magit/blob/a334412159984dcdcff3dbb56c7c1e77197cc36c/lisp/magit-stash.el#L386