### PR TITLE
feat: help menu now shows per default (disable via config: `general.s…

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Here's a list of so-far supported features:
 
 ### Keybinds
 Keybinds try mimic Magit, while staying Vim-like.
-A help-menu can be shown by pressing the `h` key.
+A help-menu can be shown by pressing the `h` key, or by configuring `general.always_show_help.enabled = true`
+
 
 <img style="width: 720px" src="vhs/help.png"/>
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,7 @@ pub(crate) struct Config {
 
 #[derive(Default, Debug, Deserialize)]
 pub struct GeneralConfig {
+    pub always_show_help: BoolConfigEntry,
     pub confirm_quit: BoolConfigEntry,
 }
 
@@ -98,9 +99,12 @@ pub(crate) fn init_config() -> Res<Config> {
 
 #[cfg(test)]
 pub(crate) fn init_test_config() -> Res<Config> {
-    Ok(Figment::new()
+    let mut config: Config = Figment::new()
         .merge(Toml::string(DEFAULT_CONFIG))
-        .extract()?)
+        .extract()?;
+
+    config.general.always_show_help.enabled = false;
+    Ok(config)
 }
 
 #[cfg(test)]

--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -3,6 +3,7 @@
 # `~/.config/gitu/config.toml`
 
 [general]
+always_show_help.enabled = false
 confirm_quit.enabled = false
 
 [style]

--- a/src/state.rs
+++ b/src/state.rs
@@ -76,6 +76,7 @@ impl State {
         };
 
         let bindings = Bindings::from(&config.bindings);
+        let pending_menu = root_menu(&config).map(PendingMenu::init);
 
         Ok(Self {
             repo,
@@ -86,7 +87,7 @@ impl State {
             quit: false,
             screens,
             pending_cmd: None,
-            pending_menu: None,
+            pending_menu,
             current_cmd_log_entries: vec![],
             prompt: prompt::Prompt::new(),
         })
@@ -207,7 +208,7 @@ impl State {
         match op {
             Op::OpenMenu(_) => (),
             Op::ToggleArg(_) => (),
-            _ => self.pending_menu = None,
+            _ => self.pending_menu = root_menu(&self.config).map(PendingMenu::init),
         }
     }
 
@@ -334,6 +335,14 @@ impl State {
         }
 
         Ok(())
+    }
+}
+
+pub(crate) fn root_menu(config: &Config) -> Option<Menu> {
+    if config.general.always_show_help.enabled {
+        Some(Menu::Help)
+    } else {
+        None
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -47,42 +47,61 @@ pub(crate) fn ui(frame: &mut Frame, state: &mut State) {
         (0, None)
     };
 
+    // TODO Clean this up...
+
     let menu_top_padding = if menu_len > 0 { 1 } else { 0 };
-    let prompt_top_padding = if state.prompt.data.is_some() { 1 } else { 0 };
     let log_top_padding = if log_len > 0 { 1 } else { 0 };
 
-    let layout = Layout::new(
-        Direction::Vertical,
-        [
-            Constraint::Min(1),
-            Constraint::Length(menu_top_padding),
-            Constraint::Length(menu_len as u16),
-            Constraint::Length(prompt_top_padding),
-            Constraint::Length(if state.prompt.data.is_some() { 1 } else { 0 }),
-            Constraint::Length(log_top_padding),
-            Constraint::Length(log_len as u16),
-        ],
-    )
-    .split(frame.size());
-
-    frame.render_widget(state.screen(), layout[0]);
-
-    if let Some(menu) = maybe_menu {
-        frame.render_widget(popup_block(), layout[1]);
-        frame.render_widget(menu, layout[2]);
-    }
-
     if let Some(prompt_data) = &state.prompt.data {
-        frame.render_widget(popup_block(), layout[3]);
+        let layout = Layout::new(
+            Direction::Vertical,
+            [
+                Constraint::Min(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(log_top_padding),
+                Constraint::Length(log_len as u16),
+            ],
+        )
+        .split(frame.size());
+
+        frame.render_widget(state.screen(), layout[0]);
+
+        frame.render_widget(popup_block(), layout[1]);
         let prompt = TextPrompt::new(prompt_data.prompt_text.clone());
-        frame.render_stateful_widget(prompt, layout[4], &mut state.prompt.state);
+        frame.render_stateful_widget(prompt, layout[2], &mut state.prompt.state);
+
+        if let Some(log) = maybe_log {
+            frame.render_widget(popup_block(), layout[3]);
+            frame.render_widget(log, layout[4]);
+        }
+
         let (cx, cy) = state.prompt.state.cursor();
         frame.set_cursor(cx, cy);
-    }
+    } else {
+        let layout = Layout::new(
+            Direction::Vertical,
+            [
+                Constraint::Min(1),
+                Constraint::Length(menu_top_padding),
+                Constraint::Length(menu_len as u16),
+                Constraint::Length(log_top_padding),
+                Constraint::Length(log_len as u16),
+            ],
+        )
+        .split(frame.size());
 
-    if let Some(log) = maybe_log {
-        frame.render_widget(popup_block(), layout[5]);
-        frame.render_widget(log, layout[6]);
+        frame.render_widget(state.screen(), layout[0]);
+
+        if let Some(menu) = maybe_menu {
+            frame.render_widget(popup_block(), layout[1]);
+            frame.render_widget(menu, layout[2]);
+        }
+
+        if let Some(log) = maybe_log {
+            frame.render_widget(popup_block(), layout[3]);
+            frame.render_widget(log, layout[4]);
+        }
     }
 }
 


### PR DESCRIPTION
…ticky_help.enabled = false`)

closes: #121

~TODO: There's an issue where the screen is unaware of its size with the help menu open.
As a result, scrolling does not behave as it should.~