### PR TITLE
Feat/stash args

### DIFF
--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -131,6 +131,8 @@ reset_menu.reset_hard = ["h"]
 reset_menu.quit = ["q", "<esc>"]
 
 root.stash_menu = ["z"]
+stash_menu.--all = ["-a"]
+stash_menu.--include-untracked = ["-u"]
 stash_menu.stash = ["z"]
 stash_menu.stash_index = ["i"]
 stash_menu.stash_worktree = ["w"]

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -200,6 +200,13 @@ pub(crate) fn create_y_n_prompt(mut action: Action, prompt: &'static str) -> Act
     })
 }
 
+pub(crate) fn create_prompt(
+    prompt: &'static str,
+    callback: fn(&mut State, &mut Term, &[OsString], &str) -> Res<()>,
+) -> Action {
+    create_prompt_with_default(prompt, callback, |_| None)
+}
+
 pub(crate) fn create_prompt_with_default(
     prompt: &'static str,
     callback: fn(&mut State, &mut Term, &[OsString], &str) -> Res<()>,

--- a/src/ops/stash.rs
+++ b/src/ops/stash.rs
@@ -14,7 +14,7 @@ pub(crate) const ARGS: &[Arg] = &[
 pub(crate) struct Stash;
 impl OpTrait for Stash {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
-        Some(create_prompt("Name of the stash", stash_push))
+        Some(create_prompt("Stash message", stash_push))
     }
 }
 
@@ -35,7 +35,7 @@ fn stash_push(state: &mut State, term: &mut Term, args: &[OsString], input: &str
 pub(crate) struct StashIndex;
 impl OpTrait for StashIndex {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
-        Some(create_prompt("Name of the stash", stash_push_index))
+        Some(create_prompt("Stash message", stash_push_index))
     }
 }
 
@@ -66,7 +66,7 @@ impl OpTrait for StashWorktree {
                 return Err("Cannot stash: working tree is empty".into());
             }
 
-            let mut create_prompt = create_prompt("Name of the stash", stash_worktree);
+            let mut create_prompt = create_prompt("Stash message", stash_worktree);
             Rc::get_mut(&mut create_prompt).unwrap()(state, term)?;
             Ok(())
         }))
@@ -142,7 +142,7 @@ fn is_something_staged(repo: &Repository) -> Res<bool> {
 pub(crate) struct StashKeepIndex;
 impl OpTrait for StashKeepIndex {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
-        Some(create_prompt("Name of the stash", stash_push_keep_index))
+        Some(create_prompt("Stash message", stash_push_keep_index))
     }
 }
 
@@ -169,7 +169,7 @@ pub(crate) struct StashPop;
 impl OpTrait for StashPop {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
         Some(create_prompt_with_default(
-            "Stash pop",
+            "Pop stash",
             stash_pop,
             selected_stash,
         ))
@@ -190,7 +190,7 @@ pub(crate) struct StashApply;
 impl OpTrait for StashApply {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
         Some(create_prompt_with_default(
-            "Stash apply",
+            "Apply stash",
             stash_apply,
             selected_stash,
         ))
@@ -211,7 +211,7 @@ pub(crate) struct StashDrop;
 impl OpTrait for StashDrop {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
         Some(create_prompt_with_default(
-            "Stash drop",
+            "Drop stash",
             stash_drop,
             selected_stash,
         ))

--- a/src/tests/snapshots/gitu__tests__stash__stash_apply_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_apply_prompt.snap
@@ -21,5 +21,5 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-? Stash apply (default 0): ›                                                    |
+? Apply stash (default 0): ›                                                    |
 styles_hash: 3e6073d833eb8d18

--- a/src/tests/snapshots/gitu__tests__stash__stash_apply_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_apply_prompt.snap
@@ -1,5 +1,5 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/stash.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |

--- a/src/tests/snapshots/gitu__tests__stash__stash_drop.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_drop.snap
@@ -1,5 +1,5 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/stash.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |
@@ -19,7 +19,7 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
-                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
-$ git stash drop -q 1                                                           |
-styles_hash: 8297e338dec91d6
+$ git stash drop 1                                                              |
+Dropped refs/stash@{1} (6e4ee08a012b0675b1f27465f158930aa1088b7a)               |
+styles_hash: dfd2a495b8602e3f

--- a/src/tests/snapshots/gitu__tests__stash__stash_drop_default.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_drop_default.snap
@@ -1,5 +1,5 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/stash.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |
@@ -19,7 +19,7 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
-                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
-$ git stash drop -q 0                                                           |
-styles_hash: 8297e338dec91d6
+$ git stash drop 0                                                              |
+Dropped refs/stash@{0} (866ae6e6fb018bbc32c37e658e097d95dceee8c0)               |
+styles_hash: dfd2a495b8602e3f

--- a/src/tests/snapshots/gitu__tests__stash__stash_drop_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_drop_prompt.snap
@@ -21,5 +21,5 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-? Stash drop (default 0): ›                                                     |
+? Drop stash (default 0): ›                                                     |
 styles_hash: 287ea763ee9469c8

--- a/src/tests/snapshots/gitu__tests__stash__stash_drop_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_drop_prompt.snap
@@ -1,5 +1,5 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/stash.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |

--- a/src/tests/snapshots/gitu__tests__stash__stash_index_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_index_prompt.snap
@@ -1,5 +1,5 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/stash.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |
@@ -21,5 +21,5 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-? Name of the stash: ›                                                          |
-styles_hash: 277490403075f8ce
+? Stash message: ›                                                              |
+styles_hash: 5ffb39001f9b126a

--- a/src/tests/snapshots/gitu__tests__stash__stash_keeping_index_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_keeping_index_prompt.snap
@@ -1,5 +1,5 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/stash.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |
@@ -21,5 +21,5 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-? Name of the stash: ›                                                          |
-styles_hash: 277490403075f8ce
+? Stash message: ›                                                              |
+styles_hash: 5ffb39001f9b126a

--- a/src/tests/snapshots/gitu__tests__stash__stash_menu.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_menu.snap
@@ -1,5 +1,5 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/stash.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |
@@ -13,13 +13,13 @@ expression: ctx.redact_buffer()
                                                                                 |
  Recent commits                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-Stash                                                                           |
-z Stash (include untracked)                                                     |
-a Apply stash                                                                   |
+Stash                      Arguments                                            |
+z Stash                    -a Also save untracked and ignored files (--all)     |
+a Apply stash              -u Also save untracked files (--include-untracked)   |
 i Stash index                                                                   |
 w Stash working tree                                                            |
 x Stash keeping index                                                           |
 p Pop stash                                                                     |
 k Drop stash                                                                    |
 q/<esc> Quit/Close                                                              |
-styles_hash: 17e2924fd3b42efd
+styles_hash: dddae6831deb0c8a

--- a/src/tests/snapshots/gitu__tests__stash__stash_pop_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_pop_prompt.snap
@@ -21,5 +21,5 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-? Stash pop (default 0): ›                                                      |
+? Pop stash (default 0): ›                                                      |
 styles_hash: fdfb8ed36c86fc3a

--- a/src/tests/snapshots/gitu__tests__stash__stash_pop_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_pop_prompt.snap
@@ -1,5 +1,5 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/stash.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |

--- a/src/tests/snapshots/gitu__tests__stash__stash_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_prompt.snap
@@ -1,5 +1,5 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/stash.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |
@@ -21,5 +21,5 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-? Name of the stash: ›                                                          |
-styles_hash: 277490403075f8ce
+? Stash message: ›                                                              |
+styles_hash: 5ffb39001f9b126a

--- a/src/tests/snapshots/gitu__tests__stash__stash_working_tree_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_working_tree_prompt.snap
@@ -1,5 +1,5 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/stash.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |

--- a/src/tests/snapshots/gitu__tests__stash__stash_working_tree_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_working_tree_prompt.snap
@@ -21,5 +21,5 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-? Name of the stash: ›                                                          |
-styles_hash: 277490403075f8ce
+? Stash message: ›                                                              |
+styles_hash: 5ffb39001f9b126a


### PR DESCRIPTION
@golden-expiriensu tagging you here in case you want to review :)

The goal here was to basically add a `cmd.args(args);` to relevant stash commands.
This will include args enabled in the menu:
```
Arguments
-a Also save untracked and ignored files (--all)
-u Also save untracked files (--include-untracked)
```

`--include-untracked` is enabled per default (and can now be toggled off).

I tried to simplify the code regarding the prompt to more align with updates in other modules!
