### PR TITLE
wip: show revert status

### DIFF
--- a/src/screen/status.rs
+++ b/src/screen/status.rs
@@ -56,6 +56,16 @@ pub(crate) fn create(config: Rc<Config>, repo: Rc<Repository>, size: Rect) -> Re
                     ..Default::default()
                 }]
                 .into_iter()
+            } else if let Some(revert) = git::revert_status(&repo)? {
+                vec![Item {
+                    id: "revert_status".into(),
+                    display: Line::styled(
+                        format!("Reverting {}", &revert.head),
+                        &style.section_header,
+                    ),
+                    ..Default::default()
+                }]
+                .into_iter()
             } else {
                 branch_status_items(&config, &repo)?.into_iter()
             }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -118,6 +118,18 @@ fn merge_conflict() {
 }
 
 #[test]
+fn revert_conflict() {
+    let mut ctx = TestContext::setup_clone();
+    commit(ctx.dir.path(), "new-file", "hey");
+    commit(ctx.dir.path(), "new-file", "hi");
+
+    run(ctx.dir.path(), &["git", "revert", "HEAD~1"]);
+
+    ctx.init_state();
+    insta::assert_snapshot!(ctx.redact_buffer());
+}
+
+#[test]
 fn moved_file() {
     let mut ctx = TestContext::setup_clone();
     commit(ctx.dir.path(), "new-file", "hello");

--- a/src/tests/snapshots/gitu__tests__revert_conflict.snap
+++ b/src/tests/snapshots/gitu__tests__revert_conflict.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/mod.rs
+expression: ctx.redact_buffer()
+---
+▌Reverting _______                                                              |
+                                                                                |
+ Unmerged                                                                       |
+ new-file                                                                       |
+                                                                                |
+ Unstaged changes (1)                                                           |
+ conflicted   new-file…                                                         |
+                                                                                |
+ Staged changes (1)                                                             |
+ conflicted   new-file…                                                         |
+                                                                                |
+ Recent commits                                                                 |
+ _______ main modify new-file                                                   |
+ _______ add new-file                                                           |
+ _______ origin/main add initial-file                                           |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: ff63c173e9d7a827


### PR DESCRIPTION
**Leaving this here in case anyone wants to pick it up!**

In CLI git, it typically shows this:
```
On branch main
Your branch is ahead of 'origin/main' by 2 commits.
  (use "git push" to publish your local commits)

You are currently reverting commit 57409cb.
  (fix conflicts and run "git revert --continue")
  (use "git revert --skip" to skip this patch)
  (use "git revert --abort" to cancel the revert operation)

Unmerged paths:
  (use "git restore --staged <file>..." to unstage)
  (use "git add/rm <file>..." as appropriate to mark resolution)
        deleted by them: new-file

no changes added to commit (use "git add" and/or "git commit -a")
```

No need to show all of this, but an indicator that we are in the "reverting state" would be useful, so that the user can revert --continue, revert --abort etc.

relates to: #110