### PR TITLE
fix: typo in descriptions on menu

### DIFF
--- a/src/ops/rebase.rs
+++ b/src/ops/rebase.rs
@@ -9,7 +9,7 @@ use std::{
 
 pub(crate) const ARGS: &[Arg] = &[
     Arg::new("--keep-empty", "Keep empty commits", false),
-    Arg::new("--preserve-merges", "Presere merges", false),
+    Arg::new("--preserve-merges", "Preserve merges", false),
     Arg::new(
         "--committer-date-is-author-date",
         "Lie about committer date",

--- a/src/tests/snapshots/gitu__tests__rebase__rebase_menu.snap
+++ b/src/tests/snapshots/gitu__tests__rebase__rebase_menu.snap
@@ -21,5 +21,5 @@ e Rebase elsewhere      -d Lie about committer date (--committer-date-is-author-
 q/<esc> Quit/Close      -i Interactive (--interactive)                          |
                         -k Keep empty commits (--keep-empty)                    |
                         -h Disable hooks (--no-verify)                          |
-                        -p Presere merges (--preserve-merges)                   |
+                        -p Preserve merges (--preserve-merges)                  |
 styles_hash: c456a01c0e45182a


### PR DESCRIPTION
Fixes a typo found in the description of an argument on the `rebase` menu.