### PR TITLE
fix(log): ignore `prefetch/remotes/` refs

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -169,7 +169,7 @@ pub(crate) fn log(
         .filter_map(
             |reference| match (reference.peel_to_commit(), reference.shorthand()) {
                 (Ok(target), Some(name)) => {
-                    if name.ends_with("/HEAD") {
+                    if name.ends_with("/HEAD") || name.starts_with("prefetch/remotes/") {
                         return None;
                     }
 


### PR DESCRIPTION
This prevents the prefeched remotes generated by `git maintenance` from polluting the git log.

The most obvious solution seems to have worked here, and this closes #138 !

Let me know if there are other bits like changelog, etc that you'd like me to sort out!