### PR TITLE
fix: bad diffs when git's `autocrlf` was enabled

### DIFF
--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -154,12 +154,13 @@ fn diff_files(
     config: &Config,
     delta: &Delta,
 ) -> Res<Vec<Rc<Hunk>>> {
-    let old_content = read_blob(repo, &diffdelta.old_file())?;
+    let old_content = read_blob(repo, &diffdelta.old_file())?.replace("\r\n", "\n");
     let new_content = if workdir {
         read_workdir(repo, &diffdelta.new_file())?
     } else {
         read_blob(repo, &diffdelta.new_file())?
-    };
+    }
+    .replace("\r\n", "\n");
 
     diff_content(config, delta, &old_content, &new_content)
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -332,3 +332,21 @@ fn syntax_highlighted() {
 
     snapshot!(ctx, "jj<tab>");
 }
+
+#[test]
+fn crlf_diff() {
+    let mut ctx = TestContext::setup_init();
+    let mut state = ctx.init_state();
+    state
+        .repo
+        .config()
+        .unwrap()
+        .set_bool("core.autocrlf", true)
+        .unwrap();
+
+    commit(ctx.dir.path(), "crlf.txt", "unchanged\r\nunchanged\r\n");
+    fs::write(ctx.dir.child("crlf.txt"), "unchanged\r\nchanged\r\n").unwrap();
+    state.update(&mut ctx.term, &keys("g")).unwrap();
+
+    insta::assert_snapshot!(ctx.redact_buffer());
+}

--- a/src/tests/snapshots/gitu__tests__crlf_diff.snap
+++ b/src/tests/snapshots/gitu__tests__crlf_diff.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/mod.rs
+expression: ctx.redact_buffer()
+---
+▌On branch main                                                                 |
+                                                                                |
+ Unstaged changes (1)                                                           |
+ modified   crlf.txt                                                            |
+ @@ -1,2 +1,2 @@                                                                |
+  unchanged                                                                     |
+ -unchanged                                                                     |
+ +changed                                                                       |
+                                                                                |
+ Recent commits                                                                 |
+ _______ main add crlf.txt                                                      |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: b27fc2c882df73ef


### PR DESCRIPTION
Before all CRLF would already be converted to LF after the diff was made (due to line 85 / how Ratatui's Text works).
Now this happens before the diff is made.

resolves: #162

I might've overlooked something, but I think this would work.
@bshashank, @rzikm