### PR TITLE
test: remove git hash redactions

### DIFF
--- a/src/tests/helpers/ui.rs
+++ b/src/tests/helpers/ui.rs
@@ -93,24 +93,6 @@ impl TestContext {
         };
         let mut debug_output = format!("{:?}", TestBuffer(test_backend.buffer()));
 
-        [&self.dir, &self.remote_dir]
-            .iter()
-            .flat_map(|dir| Repository::open(dir.path()).ok())
-            .for_each(|repo| {
-                let mut revwalk = repo.revwalk().unwrap();
-                revwalk.push_head().ok();
-                revwalk
-                    .flat_map(|maybe_oid| maybe_oid.and_then(|oid| repo.find_commit(oid)))
-                    .for_each(|commit| {
-                        let id = commit.as_object().id().to_string();
-                        let short = commit.as_object().short_id().unwrap();
-                        let short_id = short.as_str().unwrap();
-
-                        debug_output = debug_output.replace(&id, &"_".repeat(id.len()));
-                        debug_output = debug_output.replace(short_id, &"_".repeat(short_id.len()));
-                    });
-            });
-
         redact_temp_dir(&self.dir, &mut debug_output);
         redact_temp_dir(&self.remote_dir, &mut debug_output);
 

--- a/src/tests/snapshots/gitu__tests__checkout__checkout_new_branch.snap
+++ b/src/tests/snapshots/gitu__tests__checkout__checkout_new_branch.snap
@@ -5,7 +5,7 @@ expression: ctx.redact_buffer()
 ▌On branch x                                                                    |
                                                                                 |
  Recent commits                                                                 |
- _______ main x origin/main add initial-file                                    |
+ b66a0bf main x origin/main add initial-file                                    |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__crlf_diff.snap
+++ b/src/tests/snapshots/gitu__tests__crlf_diff.snap
@@ -12,7 +12,7 @@ expression: ctx.redact_buffer()
  +changed                                                                       |
                                                                                 |
  Recent commits                                                                 |
- _______ main add crlf.txt                                                      |
+ ebb4990 main add crlf.txt                                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__discard__discard_branch_yes.snap
+++ b/src/tests/snapshots/gitu__tests__discard__discard_branch_yes.snap
@@ -21,5 +21,5 @@ expression: ctx.redact_buffer()
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git branch -d asd                                                             |
-Deleted branch asd (was _______).                                               |
+Deleted branch asd (was b66a0bf).                                               |
 styles_hash: 32a139704e30d56a

--- a/src/tests/snapshots/gitu__tests__discard__discard_file_move.snap
+++ b/src/tests/snapshots/gitu__tests__discard__discard_file_move.snap
@@ -1,13 +1,13 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/discard.rs
 expression: ctx.redact_buffer()
 ---
  On branch main                                                                 |
  Your branch is ahead of 'origin/main' by 1 commit.                             |
                                                                                 |
  Recent commits                                                                 |
-▌_______ main add new-file                                                      |
- _______ origin/main add initial-file                                           |
+▌46c81ca main add new-file                                                      |
+ b66a0bf origin/main add initial-file                                           |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__discard__discard_staged_file.snap
+++ b/src/tests/snapshots/gitu__tests__discard__discard_staged_file.snap
@@ -1,13 +1,13 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/discard.rs
 expression: ctx.redact_buffer()
 ---
  On branch main                                                                 |
  Your branch is ahead of 'origin/main' by 1 commit.                             |
                                                                                 |
  Recent commits                                                                 |
-▌_______ main add file-one                                                      |
- _______ origin/main add initial-file                                           |
+▌4f3ed19 main add file-one                                                      |
+ b66a0bf origin/main add initial-file                                           |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__discard__discard_unstaged_delta.snap
+++ b/src/tests/snapshots/gitu__tests__discard__discard_unstaged_delta.snap
@@ -1,13 +1,13 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/discard.rs
 expression: ctx.redact_buffer()
 ---
  On branch main                                                                 |
  Your branch is ahead of 'origin/main' by 1 commit.                             |
                                                                                 |
  Recent commits                                                                 |
-▌_______ main add file-one                                                      |
- _______ origin/main add initial-file                                           |
+▌4f3ed19 main add file-one                                                      |
+ b66a0bf origin/main add initial-file                                           |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__discard__discard_unstaged_hunk.snap
+++ b/src/tests/snapshots/gitu__tests__discard__discard_unstaged_hunk.snap
@@ -1,13 +1,13 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/discard.rs
 expression: ctx.redact_buffer()
 ---
  On branch main                                                                 |
  Your branch is ahead of 'origin/main' by 1 commit.                             |
                                                                                 |
  Recent commits                                                                 |
- _______ main add file-one                                                      |
-▌_______ origin/main add initial-file                                           |
+ 4f3ed19 main add file-one                                                      |
+▌b66a0bf origin/main add initial-file                                           |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__discard__discard_untracked_file.snap
+++ b/src/tests/snapshots/gitu__tests__discard__discard_untracked_file.snap
@@ -1,12 +1,12 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/discard.rs
 expression: ctx.redact_buffer()
 ---
  On branch main                                                                 |
  Your branch is up to date with 'origin/main'.                                  |
                                                                                 |
  Recent commits                                                                 |
-▌_______ main origin/main add initial-file                                      |
+▌b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__discard__discard_untracked_staged_file.snap
+++ b/src/tests/snapshots/gitu__tests__discard__discard_untracked_staged_file.snap
@@ -1,12 +1,12 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/discard.rs
 expression: ctx.redact_buffer()
 ---
  On branch main                                                                 |
  Your branch is up to date with 'origin/main'.                                  |
                                                                                 |
  Recent commits                                                                 |
-▌_______ main origin/main add initial-file                                      |
+▌b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__fetch__fetch_from_elsewhere.snap
+++ b/src/tests/snapshots/gitu__tests__fetch__fetch_from_elsewhere.snap
@@ -6,7 +6,7 @@ expression: ctx.redact_buffer()
 ▌Your branch is up to date with 'origin/main'.                                  |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__fetch__fetch_from_elsewhere_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__fetch__fetch_from_elsewhere_prompt.snap
@@ -6,7 +6,7 @@ expression: ctx.redact_buffer()
 ▌Your branch is up to date with 'origin/main'.                                  |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__fetch_all.snap
+++ b/src/tests/snapshots/gitu__tests__fetch_all.snap
@@ -6,7 +6,7 @@ expression: ctx.redact_buffer()
 ▌Your branch is behind 'origin/main' by 1 commit.                               |
                                                                                 |
  Recent commits                                                                 |
- _______ main add initial-file                                                  |
+ b66a0bf main add initial-file                                                  |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -21,5 +21,5 @@ expression: ctx.redact_buffer()
 ────────────────────────────────────────────────────────────────────────────────|
 $ git fetch --all --jobs 10                                                     |
 From                                                                            |
-   _______.._______  main       -> origin/main                                  |
+   b66a0bf..d07f2d3  main       -> origin/main                                  |
 styles_hash: 362e47f9c483be51

--- a/src/tests/snapshots/gitu__tests__go_down_past_collapsed.snap
+++ b/src/tests/snapshots/gitu__tests__go_down_past_collapsed.snap
@@ -9,8 +9,8 @@ expression: ctx.redact_buffer()
 ▌modified   file-two…                                                           |
                                                                                 |
  Recent commits                                                                 |
- _______ main add file-two                                                      |
- _______ add file-one                                                           |
+ ba7ba58 main add file-two                                                      |
+ 428f4a7 add file-one                                                           |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__hide_untracked.snap
+++ b/src/tests/snapshots/gitu__tests__hide_untracked.snap
@@ -6,7 +6,7 @@ expression: ctx.redact_buffer()
 ▌Your branch is up to date with 'origin/main'.                                  |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__inside_submodule.snap
+++ b/src/tests/snapshots/gitu__tests__inside_submodule.snap
@@ -6,7 +6,7 @@ expression: ctx.redact_buffer()
 ▌Your branch is up to date with 'origin/main'.                                  |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__log.snap
+++ b/src/tests/snapshots/gitu__tests__log.snap
@@ -2,9 +2,9 @@
 source: src/tests/mod.rs
 expression: ctx.redact_buffer()
 ---
-▌_______ main a-tag add secondfile                                              |
- _______ annotated add firstfile                                                |
- _______ origin/main add initial-file                                           |
+▌0c2c6c3 main a-tag add secondfile                                              |
+ 223428c annotated add firstfile                                                |
+ b66a0bf origin/main add initial-file                                           |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__log__grep_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__log__grep_prompt.snap
@@ -6,10 +6,10 @@ expression: ctx.redact_buffer()
 ▌Your branch is ahead of 'origin/main' by 3 commit.                             |
                                                                                 |
  Recent commits                                                                 |
- _______ main add first commit                                                  |
- _______ add second commit                                                      |
- _______ add third commit                                                       |
- _______ origin/main add initial-file                                           |
+ 8bb5532 main add first commit                                                  |
+ 6c08cf7 add second commit                                                      |
+ 79e63f1 add third commit                                                       |
+ b66a0bf origin/main add initial-file                                           |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__log__grep_second.snap
+++ b/src/tests/snapshots/gitu__tests__log__grep_second.snap
@@ -2,7 +2,7 @@
 source: src/tests/log.rs
 expression: ctx.redact_buffer()
 ---
-▌_______ add second commit                                                      |
+▌6c08cf7 add second commit                                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__log__grep_second_other.snap
+++ b/src/tests/snapshots/gitu__tests__log__grep_second_other.snap
@@ -2,7 +2,7 @@
 source: src/tests/log.rs
 expression: ctx.redact_buffer()
 ---
-▌_______ add second commit                                                      |
+▌6c08cf7 add second commit                                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__log__grep_set_example.snap
+++ b/src/tests/snapshots/gitu__tests__log__grep_set_example.snap
@@ -6,10 +6,10 @@ expression: ctx.redact_buffer()
 ▌Your branch is ahead of 'origin/main' by 3 commit.                             |
                                                                                 |
  Recent commits                                                                 |
- _______ main add first commit                                                  |
- _______ add second commit                                                      |
- _______ add third commit                                                       |
- _______ origin/main add initial-file                                           |
+ 8bb5532 main add first commit                                                  |
+ 6c08cf7 add second commit                                                      |
+ 79e63f1 add third commit                                                       |
+ b66a0bf origin/main add initial-file                                           |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__log__limit_2_commits.snap
+++ b/src/tests/snapshots/gitu__tests__log__limit_2_commits.snap
@@ -2,8 +2,8 @@
 source: src/tests/log.rs
 expression: ctx.redact_buffer()
 ---
-▌_______ main add first commit                                                  |
- _______ add second commit                                                      |
+▌8bb5532 main add first commit                                                  |
+ 6c08cf7 add second commit                                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__log__limit_2_commits_other.snap
+++ b/src/tests/snapshots/gitu__tests__log__limit_2_commits_other.snap
@@ -2,8 +2,8 @@
 source: src/tests/log.rs
 expression: ctx.redact_buffer()
 ---
-▌_______ main add first commit                                                  |
- _______ add second commit                                                      |
+▌8bb5532 main add first commit                                                  |
+ 6c08cf7 add second commit                                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__log__limit_invalid.snap
+++ b/src/tests/snapshots/gitu__tests__log__limit_invalid.snap
@@ -6,10 +6,10 @@ expression: ctx.redact_buffer()
 ▌Your branch is ahead of 'origin/main' by 3 commit.                             |
                                                                                 |
  Recent commits                                                                 |
- _______ main add first commit                                                  |
- _______ add second commit                                                      |
- _______ add third commit                                                       |
- _______ origin/main add initial-file                                           |
+ 8bb5532 main add first commit                                                  |
+ 6c08cf7 add second commit                                                      |
+ 79e63f1 add third commit                                                       |
+ b66a0bf origin/main add initial-file                                           |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__log__limit_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__log__limit_prompt.snap
@@ -6,10 +6,10 @@ expression: ctx.redact_buffer()
 ▌Your branch is ahead of 'origin/main' by 3 commit.                             |
                                                                                 |
  Recent commits                                                                 |
- _______ main add first commit                                                  |
- _______ add second commit                                                      |
- _______ add third commit                                                       |
- _______ origin/main add initial-file                                           |
+ 8bb5532 main add first commit                                                  |
+ 6c08cf7 add second commit                                                      |
+ 79e63f1 add third commit                                                       |
+ b66a0bf origin/main add initial-file                                           |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__log__limit_set_10.snap
+++ b/src/tests/snapshots/gitu__tests__log__limit_set_10.snap
@@ -6,10 +6,10 @@ expression: ctx.redact_buffer()
 ▌Your branch is ahead of 'origin/main' by 3 commit.                             |
                                                                                 |
  Recent commits                                                                 |
- _______ main add first commit                                                  |
- _______ add second commit                                                      |
- _______ add third commit                                                       |
- _______ origin/main add initial-file                                           |
+ 8bb5532 main add first commit                                                  |
+ 6c08cf7 add second commit                                                      |
+ 79e63f1 add third commit                                                       |
+ b66a0bf origin/main add initial-file                                           |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__log__log_other.snap
+++ b/src/tests/snapshots/gitu__tests__log__log_other.snap
@@ -2,9 +2,9 @@
 source: src/tests/log.rs
 expression: ctx.redact_buffer()
 ---
-▌_______ add second commit                                                      |
- _______ add third commit                                                       |
- _______ origin/main add initial-file                                           |
+▌6c08cf7 add second commit                                                      |
+ 79e63f1 add third commit                                                       |
+ b66a0bf origin/main add initial-file                                           |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__log__log_other_input.snap
+++ b/src/tests/snapshots/gitu__tests__log__log_other_input.snap
@@ -2,9 +2,9 @@
 source: src/tests/log.rs
 expression: ctx.redact_buffer()
 ---
-▌_______ add second commit                                                      |
- _______ add third commit                                                       |
- _______ origin/main add initial-file                                           |
+▌6c08cf7 add second commit                                                      |
+ 79e63f1 add third commit                                                       |
+ b66a0bf origin/main add initial-file                                           |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__log__log_other_invalid.snap
+++ b/src/tests/snapshots/gitu__tests__log__log_other_invalid.snap
@@ -6,10 +6,10 @@ expression: ctx.redact_buffer()
 ▌Your branch is ahead of 'origin/main' by 3 commit.                             |
                                                                                 |
  Recent commits                                                                 |
- _______ main add first commit                                                  |
- _______ add second commit                                                      |
- _______ add third commit                                                       |
- _______ origin/main add initial-file                                           |
+ 8bb5532 main add first commit                                                  |
+ 6c08cf7 add second commit                                                      |
+ 79e63f1 add third commit                                                       |
+ b66a0bf origin/main add initial-file                                           |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__log__log_other_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__log__log_other_prompt.snap
@@ -2,10 +2,10 @@
 source: src/tests/log.rs
 expression: ctx.redact_buffer()
 ---
- _______ main add first commit                                                  |
-▌_______ add second commit                                                      |
- _______ add third commit                                                       |
- _______ origin/main add initial-file                                           |
+ 8bb5532 main add first commit                                                  |
+▌6c08cf7 add second commit                                                      |
+ 79e63f1 add third commit                                                       |
+ b66a0bf origin/main add initial-file                                           |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -21,5 +21,5 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-? Log rev (default ________________________________________): ›                 |
+? Log rev (default 6c08cf78a4544ae4dda8e6161a61070867c60246): ›                 |
 styles_hash: b9fd13286ebd29fe

--- a/src/tests/snapshots/gitu__tests__merge_conflict.snap
+++ b/src/tests/snapshots/gitu__tests__merge_conflict.snap
@@ -14,9 +14,9 @@ expression: ctx.redact_buffer()
  conflicted   new-file…                                                         |
                                                                                 |
  Recent commits                                                                 |
- _______ main modify new-file                                                   |
- _______ add new-file                                                           |
- _______ origin/main add initial-file                                           |
+ ed5ed59 main modify new-file                                                   |
+ 46c81ca add new-file                                                           |
+ b66a0bf origin/main add initial-file                                           |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__moved_file.snap
+++ b/src/tests/snapshots/gitu__tests__moved_file.snap
@@ -10,8 +10,8 @@ expression: ctx.redact_buffer()
  deleted   new-file…                                                            |
                                                                                 |
  Recent commits                                                                 |
- _______ main add new-file                                                      |
- _______ origin/main add initial-file                                           |
+ 46c81ca main add new-file                                                      |
+ b66a0bf origin/main add initial-file                                           |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__new_commit.snap
+++ b/src/tests/snapshots/gitu__tests__new_commit.snap
@@ -6,8 +6,8 @@ expression: ctx.redact_buffer()
 ▌Your branch is ahead of 'origin/main' by 1 commit.                             |
                                                                                 |
  Recent commits                                                                 |
- _______ main add new-file                                                      |
- _______ origin/main add initial-file                                           |
+ e7eb2bd main add new-file                                                      |
+ b66a0bf origin/main add initial-file                                           |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__pull.snap
+++ b/src/tests/snapshots/gitu__tests__pull.snap
@@ -6,8 +6,8 @@ expression: ctx.redact_buffer()
 ▌Your branch is up to date with 'origin/main'.                                  |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add remote-file                                       |
- _______ add initial-file                                                       |
+ d07f2d3 main origin/main add remote-file                                       |
+ b66a0bf add initial-file                                                       |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -16,8 +16,8 @@ expression: ctx.redact_buffer()
 ────────────────────────────────────────────────────────────────────────────────|
 $ git pull                                                                      |
 From                                                                            |
-   _______.._______  main       -> origin/main                                  |
-Updating _______.._______                                                       |
+   b66a0bf..d07f2d3  main       -> origin/main                                  |
+Updating b66a0bf..d07f2d3                                                       |
 Fast-forward                                                                    |
  remote-file | 1 +                                                              |
  1 file changed, 1 insertion(+)                                                 |

--- a/src/tests/snapshots/gitu__tests__pull__pull_from_elsewhere.snap
+++ b/src/tests/snapshots/gitu__tests__pull__pull_from_elsewhere.snap
@@ -6,7 +6,7 @@ expression: ctx.redact_buffer()
 ▌Your branch is up to date with 'origin/main'.                                  |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__pull__pull_from_elsewhere_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__pull__pull_from_elsewhere_prompt.snap
@@ -6,7 +6,7 @@ expression: ctx.redact_buffer()
 ▌Your branch is up to date with 'origin/main'.                                  |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__push__force_push.snap
+++ b/src/tests/snapshots/gitu__tests__push__force_push.snap
@@ -1,13 +1,13 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/push.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |
 ▌Your branch is up to date with 'origin/main'.                                  |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add new-file                                          |
- _______ add initial-file                                                       |
+ e7eb2bd main origin/main add new-file                                          |
+ b66a0bf add initial-file                                                       |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -21,5 +21,5 @@ expression: ctx.redact_buffer()
 ────────────────────────────────────────────────────────────────────────────────|
 $ git push --force-with-lease                                                   |
 To                                                                              |
-   _______.._______  main -> main                                               |
+   b66a0bf..e7eb2bd  main -> main                                               |
 styles_hash: 87eedce2925134fb

--- a/src/tests/snapshots/gitu__tests__push__open_push_menu_after_dash_input.snap
+++ b/src/tests/snapshots/gitu__tests__push__open_push_menu_after_dash_input.snap
@@ -6,8 +6,8 @@ expression: ctx.redact_buffer()
 ▌Your branch is ahead of 'origin/main' by 1 commit.                             |
                                                                                 |
  Recent commits                                                                 |
- _______ main add new-file                                                      |
- _______ origin/main add initial-file                                           |
+ e7eb2bd main add new-file                                                      |
+ b66a0bf origin/main add initial-file                                           |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__push__push.snap
+++ b/src/tests/snapshots/gitu__tests__push__push.snap
@@ -1,13 +1,13 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/push.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |
 ▌Your branch is up to date with 'origin/main'.                                  |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add new-file                                          |
- _______ add initial-file                                                       |
+ e7eb2bd main origin/main add new-file                                          |
+ b66a0bf add initial-file                                                       |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -21,5 +21,5 @@ expression: ctx.redact_buffer()
 ────────────────────────────────────────────────────────────────────────────────|
 $ git push                                                                      |
 To                                                                              |
-   _______.._______  main -> main                                               |
+   b66a0bf..e7eb2bd  main -> main                                               |
 styles_hash: 4b89bed7f095a906

--- a/src/tests/snapshots/gitu__tests__push__push_elsewhere.snap
+++ b/src/tests/snapshots/gitu__tests__push__push_elsewhere.snap
@@ -6,7 +6,7 @@ expression: ctx.redact_buffer()
 ▌Your branch is up to date with 'origin/main'.                                  |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__push__push_elsewhere_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__push__push_elsewhere_prompt.snap
@@ -6,7 +6,7 @@ expression: ctx.redact_buffer()
 ▌Your branch is up to date with 'origin/main'.                                  |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__rebase__rebase_elsewhere.snap
+++ b/src/tests/snapshots/gitu__tests__rebase__rebase_elsewhere.snap
@@ -5,8 +5,8 @@ expression: ctx.redact_buffer()
 ▌On branch other-branch                                                         |
                                                                                 |
  Recent commits                                                                 |
- _______ main other-branch add new-file                                         |
- _______ origin/main add initial-file                                           |
+ 46c81ca main other-branch add new-file                                         |
+ b66a0bf origin/main add initial-file                                           |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__rebase__rebase_elsewhere_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__rebase__rebase_elsewhere_prompt.snap
@@ -5,7 +5,7 @@ expression: ctx.redact_buffer()
 ▌On branch other-branch                                                         |
                                                                                 |
  Recent commits                                                                 |
- _______ other-branch origin/main add initial-file                              |
+ b66a0bf other-branch origin/main add initial-file                              |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__rebase__rebase_menu.snap
+++ b/src/tests/snapshots/gitu__tests__rebase__rebase_menu.snap
@@ -5,7 +5,7 @@ expression: ctx.redact_buffer()
 ▌On branch other-branch                                                         |
                                                                                 |
  Recent commits                                                                 |
- _______ other-branch origin/main add initial-file                              |
+ b66a0bf other-branch origin/main add initial-file                              |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__rebase_conflict.snap
+++ b/src/tests/snapshots/gitu__tests__rebase_conflict.snap
@@ -14,9 +14,9 @@ expression: ctx.redact_buffer()
  conflicted   new-file…                                                         |
                                                                                 |
  Recent commits                                                                 |
- _______ main modify new-file                                                   |
- _______ add new-file                                                           |
- _______ origin/main add initial-file                                           |
+ ed5ed59 main modify new-file                                                   |
+ 46c81ca add new-file                                                           |
+ b66a0bf origin/main add initial-file                                           |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__reset__reset_hard.snap
+++ b/src/tests/snapshots/gitu__tests__reset__reset_hard.snap
@@ -1,12 +1,12 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/reset.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |
 ▌Your branch is up to date with 'origin/main'.                                  |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__reset__reset_menu.snap
+++ b/src/tests/snapshots/gitu__tests__reset__reset_menu.snap
@@ -1,9 +1,9 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/reset.rs
 expression: ctx.redact_buffer()
 ---
- _______ main add unwanted-file                                                 |
-▌_______ origin/main add initial-file                                           |
+ ba1a85d main add unwanted-file                                                 |
+▌b66a0bf origin/main add initial-file                                           |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__reset__reset_mixed.snap
+++ b/src/tests/snapshots/gitu__tests__reset__reset_mixed.snap
@@ -1,5 +1,5 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/reset.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |
@@ -9,7 +9,7 @@ expression: ctx.redact_buffer()
  unwanted-file                                                                  |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__reset__reset_soft.snap
+++ b/src/tests/snapshots/gitu__tests__reset__reset_soft.snap
@@ -1,5 +1,5 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/reset.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |
@@ -9,7 +9,7 @@ expression: ctx.redact_buffer()
  added   unwanted-file                                                          |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__reset__reset_soft_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__reset__reset_soft_prompt.snap
@@ -1,9 +1,9 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/reset.rs
 expression: ctx.redact_buffer()
 ---
- _______ main add unwanted-file                                                 |
-▌_______ origin/main add initial-file                                           |
+ ba1a85d main add unwanted-file                                                 |
+▌b66a0bf origin/main add initial-file                                           |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -21,5 +21,5 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-? Soft reset to (default ________________________________________): › q         |
+? Soft reset to (default b66a0bf82020d6a386e94d0fceedec1f817d20c7): › q         |
 styles_hash: 174798f428e40bd6

--- a/src/tests/snapshots/gitu__tests__revert_abort.snap
+++ b/src/tests/snapshots/gitu__tests__revert_abort.snap
@@ -6,9 +6,9 @@ expression: ctx.redact_buffer()
 ▌Your branch is ahead of 'origin/main' by 2 commit.                             |
                                                                                 |
  Recent commits                                                                 |
- _______ main modify new-file                                                   |
- _______ add new-file                                                           |
- _______ origin/main add initial-file                                           |
+ 7294ba4 main modify new-file                                                   |
+ 57409cb add new-file                                                           |
+ b66a0bf origin/main add initial-file                                           |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__revert_commit.snap
+++ b/src/tests/snapshots/gitu__tests__revert_commit.snap
@@ -2,8 +2,8 @@
 source: src/tests/mod.rs
 expression: ctx.redact_buffer()
 ---
-▌_______ main Revert "add initial-file"                                         |
- _______ origin/main add initial-file                                           |
+▌6324471 main Revert "add initial-file"                                         |
+ b66a0bf origin/main add initial-file                                           |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -21,5 +21,5 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-$ git revert ________________________________________                           |
+$ git revert b66a0bf82020d6a386e94d0fceedec1f817d20c7                           |
 styles_hash: b8c40dcdc41cf963

--- a/src/tests/snapshots/gitu__tests__revert_commit_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__revert_commit_prompt.snap
@@ -2,7 +2,7 @@
 source: src/tests/mod.rs
 expression: ctx.redact_buffer()
 ---
-▌_______ main origin/main add initial-file                                      |
+▌b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -21,5 +21,5 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-? Revert commit (default ________________________________________): ›           |
+? Revert commit (default b66a0bf82020d6a386e94d0fceedec1f817d20c7): ›           |
 styles_hash: 78116180725b01d8

--- a/src/tests/snapshots/gitu__tests__revert_conflict.snap
+++ b/src/tests/snapshots/gitu__tests__revert_conflict.snap
@@ -2,7 +2,7 @@
 source: src/tests/mod.rs
 expression: ctx.redact_buffer()
 ---
-▌Reverting _______                                                              |
+▌Reverting 57409cb                                                              |
                                                                                 |
  Unmerged                                                                       |
  new-file                                                                       |
@@ -14,9 +14,9 @@ expression: ctx.redact_buffer()
  conflicted   new-file…                                                         |
                                                                                 |
  Recent commits                                                                 |
- _______ main modify new-file                                                   |
- _______ add new-file                                                           |
- _______ origin/main add initial-file                                           |
+ 7294ba4 main modify new-file                                                   |
+ 57409cb add new-file                                                           |
+ b66a0bf origin/main add initial-file                                           |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__revert_menu.snap
+++ b/src/tests/snapshots/gitu__tests__revert_menu.snap
@@ -2,7 +2,7 @@
 source: src/tests/mod.rs
 expression: ctx.redact_buffer()
 ---
-▌_______ main origin/main add initial-file                                      |
+▌b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__show.snap
+++ b/src/tests/snapshots/gitu__tests__show.snap
@@ -2,7 +2,7 @@
 source: src/tests/mod.rs
 expression: ctx.redact_buffer()
 ---
- commit ________________________________________                                |
+ commit cd0a1c1f653ae15d2b920922e04046a2453d2afb                                |
  Author: Author Name <author@email.com>                                         |
  Date:   Fri, 16 Feb 2024 11:11:00 +0100                                        |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__stage__stage_all_unstaged.snap
+++ b/src/tests/snapshots/gitu__tests__stage__stage_all_unstaged.snap
@@ -1,5 +1,5 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/stage.rs
 expression: ctx.redact_buffer()
 ---
  On branch main                                                                 |
@@ -9,8 +9,8 @@ expression: ctx.redact_buffer()
 ▌modified   secondfile…                                                         |
                                                                                 |
  Recent commits                                                                 |
- _______ main add secondfile                                                    |
- _______ add firstfile                                                          |
+ a735817 main add secondfile                                                    |
+ 95a979d add firstfile                                                          |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__stage__stage_changes_crlf.snap
+++ b/src/tests/snapshots/gitu__tests__stage__stage_changes_crlf.snap
@@ -12,7 +12,7 @@ expression: ctx.redact_buffer()
 ▌ testtest                                                                      |
                                                                                 |
  Recent commits                                                                 |
- _______ main add testfile                                                      |
+ c0bec93 main add testfile                                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__stage__stage_removed_line.snap
+++ b/src/tests/snapshots/gitu__tests__stage__stage_removed_line.snap
@@ -18,7 +18,7 @@ expression: ctx.redact_buffer()
   testtest                                                                      |
                                                                                 |
  Recent commits                                                                 |
- _______ main add firstfile                                                     |
+ 95a979d main add firstfile                                                     |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git apply --cached --recount                                                  |

--- a/src/tests/snapshots/gitu__tests__stage_last_hunk_of_first_delta.snap
+++ b/src/tests/snapshots/gitu__tests__stage_last_hunk_of_first_delta.snap
@@ -15,9 +15,9 @@ expression: ctx.redact_buffer()
   blahonga                                                                      |
                                                                                 |
  Recent commits                                                                 |
- _______ main add file-two                                                      |
- _______ add file-one                                                           |
- _______ origin/main add initial-file                                           |
+ e45938a main add file-two                                                      |
+ b3cf8e8 add file-one                                                           |
+ b66a0bf origin/main add initial-file                                           |
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|

--- a/src/tests/snapshots/gitu__tests__stash__stash.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash.snap
@@ -1,5 +1,5 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/stash.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |
@@ -9,7 +9,7 @@ expression: ctx.redact_buffer()
  stash@0 On main: test                                                          |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__stash__stash_apply.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_apply.snap
@@ -15,7 +15,7 @@ expression: ctx.redact_buffer()
  stash@1 On main: file-one                                                      |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__stash__stash_apply_default.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_apply_default.snap
@@ -1,5 +1,5 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/stash.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |
@@ -13,7 +13,7 @@ expression: ctx.redact_buffer()
  stash@1 On main: file-one                                                      |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__stash__stash_apply_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_apply_prompt.snap
@@ -10,7 +10,7 @@ expression: ctx.redact_buffer()
  stash@1 On main: file-one                                                      |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__stash__stash_drop.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_drop.snap
@@ -9,7 +9,7 @@ expression: ctx.redact_buffer()
  stash@0 On main: file-two                                                      |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__stash__stash_drop_default.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_drop_default.snap
@@ -9,7 +9,7 @@ expression: ctx.redact_buffer()
  stash@0 On main: file-one                                                      |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__stash__stash_drop_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_drop_prompt.snap
@@ -10,7 +10,7 @@ expression: ctx.redact_buffer()
  stash@1 On main: file-one                                                      |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__stash__stash_index.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_index.snap
@@ -1,5 +1,5 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/stash.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |
@@ -12,7 +12,7 @@ expression: ctx.redact_buffer()
  stash@0 On main: test                                                          |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__stash__stash_index_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_index_prompt.snap
@@ -12,7 +12,7 @@ expression: ctx.redact_buffer()
  added   file-one…                                                              |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__stash__stash_keeping_index.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_keeping_index.snap
@@ -1,5 +1,5 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/stash.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |
@@ -12,7 +12,7 @@ expression: ctx.redact_buffer()
  stash@0 On main: test                                                          |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__stash__stash_keeping_index_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_keeping_index_prompt.snap
@@ -12,7 +12,7 @@ expression: ctx.redact_buffer()
  added   file-one…                                                              |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__stash__stash_pop.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_pop.snap
@@ -14,7 +14,7 @@ expression: ctx.redact_buffer()
  stash@0 On main: file-two                                                      |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__stash__stash_pop_default.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_pop_default.snap
@@ -1,5 +1,5 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/stash.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |
@@ -12,7 +12,7 @@ expression: ctx.redact_buffer()
  stash@0 On main: file-one                                                      |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__stash__stash_pop_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_pop_prompt.snap
@@ -10,7 +10,7 @@ expression: ctx.redact_buffer()
  stash@1 On main: file-one                                                      |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__stash__stash_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_prompt.snap
@@ -12,7 +12,7 @@ expression: ctx.redact_buffer()
  added   file-one…                                                              |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__stash__stash_working_tree.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_working_tree.snap
@@ -1,5 +1,5 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/stash.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |
@@ -12,13 +12,13 @@ expression: ctx.redact_buffer()
  stash@0 On main: test                                                          |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git stash push --staged                                                       |
-Saved working directory and index state WIP on main: _______ add initial-file   |
+Saved working directory and index state WIP on main: b66a0bf add initial-file   |
 $ git stash push --include-untracked --message test                             |
 Saved working directory and index state On main: test                           |
 $ git stash pop -q 1                                                            |

--- a/src/tests/snapshots/gitu__tests__stash__stash_working_tree_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_working_tree_prompt.snap
@@ -12,7 +12,7 @@ expression: ctx.redact_buffer()
  added   file-one…                                                              |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__stash__stash_working_tree_when_everything_is_staged.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_working_tree_when_everything_is_staged.snap
@@ -12,7 +12,7 @@ expression: ctx.redact_buffer()
 ▌+blahonga                                                                      |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__stash__stash_working_tree_when_nothing_is_staged.snap
+++ b/src/tests/snapshots/gitu__tests__stash__stash_working_tree_when_nothing_is_staged.snap
@@ -1,5 +1,5 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/stash.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |
@@ -9,7 +9,7 @@ expression: ctx.redact_buffer()
  stash@0 On main: test                                                          |
                                                                                 |
  Recent commits                                                                 |
- _______ main origin/main add initial-file                                      |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__syntax_highlighted.snap
+++ b/src/tests/snapshots/gitu__tests__syntax_highlighted.snap
@@ -13,7 +13,7 @@ expression: ctx.redact_buffer()
 ▌ }                                                                             |
                                                                                 |
  Recent commits                                                                 |
- _______ main add syntax-highlighted.rs                                         |
+ de7e4d3 main add syntax-highlighted.rs                                         |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__tab_diff.snap
+++ b/src/tests/snapshots/gitu__tests__tab_diff.snap
@@ -11,7 +11,7 @@ expression: ctx.redact_buffer()
  +    this has a tab prefixed                                                   |
                                                                                 |
  Recent commits                                                                 |
- _______ main add tab.txt                                                       |
+ bbba724 main add tab.txt                                                       |
                                                                                 |
                                                                                 |
                                                                                 |

--- a/src/tests/snapshots/gitu__tests__unstage__unstage_added_line.snap
+++ b/src/tests/snapshots/gitu__tests__unstage__unstage_added_line.snap
@@ -18,7 +18,7 @@ expression: ctx.redact_buffer()
  +blrergh                                                                       |
                                                                                 |
  Recent commits                                                                 |
- _______ main add firstfile                                                     |
+ 95a979d main add firstfile                                                     |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git apply --cached --reverse --recount                                        |

--- a/src/tests/snapshots/gitu__tests__unstaged_changes.snap
+++ b/src/tests/snapshots/gitu__tests__unstaged_changes.snap
@@ -12,7 +12,7 @@ expression: ctx.redact_buffer()
 ▌ testtest                                                                      |
                                                                                 |
  Recent commits                                                                 |
- _______ main add testfile                                                      |
+ f431046 main add testfile                                                      |
                                                                                 |
                                                                                 |
                                                                                 |


### PR DESCRIPTION
Is the same hash guaranteed to be the same every time, across platform? I guess we'll find out in CI.