### PR TITLE
test(all): restore terminal state when finished.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,6 +441,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "ctor"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,6 +683,7 @@ dependencies = [
  "clap",
  "criterion",
  "crossterm",
+ "ctor",
  "derive_more",
  "etcetera",
  "figment",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ name = "show"
 harness = false
 
 [dev-dependencies]
+ctor = "0.2.7"
 pretty_assertions = "1.4.0"
 temp-dir = "0.1.13"
 criterion = "0.5.1"
@@ -20,7 +21,9 @@ unicode-width = "0.1.12"
 strip = true
 
 [dependencies]
-arboard = { version = "3.4.0", default-features = false, features = ["windows-sys"] }
+arboard = { version = "3.4.0", default-features = false, features = [
+  "windows-sys",
+] }
 chrono = "0.4.38"
 clap = { version = "4.5.9", features = ["derive"] }
 crossterm = "0.27.0"

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -19,6 +19,15 @@ mod unstage;
 
 use helpers::{clone_and_commit, commit, keys, run, TestContext};
 
+use crate::term;
+
+#[cfg(test)]
+#[ctor::dtor]
+fn restore_terminal() {
+    term::cleanup_alternate_screen();
+    term::cleanup_raw_mode();
+}
+
 #[test]
 fn no_repo() {
     let mut ctx = TestContext::setup_init();


### PR DESCRIPTION
Runnin `cargo t` used to leave the terminal in a bad state: no mouse input is interpreted right, scrolling is gone, etc.