### PR TITLE
fix: instant fixup commit would not work with some versions of Git

### DIFF
--- a/src/ops/commit.rs
+++ b/src/ops/commit.rs
@@ -118,8 +118,15 @@ impl OpTrait for CommitInstantFixup {
 
 fn rebase_autosquash_cmd(rev: &OsStr) -> Command {
     let mut cmd = Command::new("git");
-    cmd.args(["rebase", "--autostash", "--keep-empty", "--autosquash"]);
+    cmd.args([
+        "rebase",
+        "-i",
+        "--autostash",
+        "--keep-empty",
+        "--autosquash",
+    ]);
     cmd.arg(&parent(rev));
+    cmd.env("GIT_SEQUENCE_EDITOR", ":");
     cmd
 }
 

--- a/src/ops/commit.rs
+++ b/src/ops/commit.rs
@@ -121,6 +121,7 @@ fn rebase_autosquash_cmd(rev: &OsStr) -> Command {
     cmd.args([
         "rebase",
         "-i",
+        "-q",
         "--autostash",
         "--keep-empty",
         "--autosquash",

--- a/src/tests/snapshots/gitu__tests__commit__commit_instant_fixup.snap
+++ b/src/tests/snapshots/gitu__tests__commit__commit_instant_fixup.snap
@@ -15,11 +15,11 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git commit --fixup b6eadadbf0b746c00135b317fab80d9801c2d7bb                   |
 [main aa71b64] fixup! modify instant_fixup.txt                                  |
  Author: Author Name <author@email.com>                                         |
  1 file changed, 1 insertion(+), 1 deletion(-)                                  |
-$ git rebase -i --autostash --keep-empty --autosquash b6eadadbf0b746c00135b317fa|
-Rebasing (2/2)[KSuccessfully rebased and updated refs/heads/main.            |
-styles_hash: ae3f5d3376fa30e5
+$ git rebase -i -q --autostash --keep-empty --autosquash b6eadadbf0b746c00135b31|
+styles_hash: 775b3fc3b27812e8

--- a/src/tests/snapshots/gitu__tests__commit__commit_instant_fixup.snap
+++ b/src/tests/snapshots/gitu__tests__commit__commit_instant_fixup.snap
@@ -20,6 +20,6 @@ $ git commit --fixup b6eadadbf0b746c00135b317fab80d9801c2d7bb                   
 [main aa71b64] fixup! modify instant_fixup.txt                                  |
  Author: Author Name <author@email.com>                                         |
  1 file changed, 1 insertion(+), 1 deletion(-)                                  |
-$ git rebase --autostash --keep-empty --autosquash b6eadadbf0b746c00135b317fab80|
+$ git rebase -i --autostash --keep-empty --autosquash b6eadadbf0b746c00135b317fa|
 Rebasing (2/2)[KSuccessfully rebased and updated refs/heads/main.            |
 styles_hash: ae3f5d3376fa30e5

--- a/src/tests/snapshots/gitu__tests__commit__commit_instant_fixup_stashes_changes_and_keeps_empty.snap
+++ b/src/tests/snapshots/gitu__tests__commit__commit_instant_fixup_stashes_changes_and_keeps_empty.snap
@@ -18,7 +18,7 @@ $ git commit --fixup b6eadadbf0b746c00135b317fab80d9801c2d7bb                   
 [main c0f1150] fixup! modify instant_fixup.txt                                  |
  Author: Author Name <author@email.com>                                         |
  1 file changed, 1 insertion(+), 1 deletion(-)                                  |
-$ git rebase --autostash --keep-empty --autosquash b6eadadbf0b746c00135b317fab80|
+$ git rebase -i --autostash --keep-empty --autosquash b6eadadbf0b746c00135b317fa|
 Rebasing (2/3)Rebasing (3/3)Applied autostash.                                |
 [KSuccessfully rebased and updated refs/heads/main.                           |
 Created autostash: bc5bcfb                                                      |

--- a/src/tests/snapshots/gitu__tests__commit__commit_instant_fixup_stashes_changes_and_keeps_empty.snap
+++ b/src/tests/snapshots/gitu__tests__commit__commit_instant_fixup_stashes_changes_and_keeps_empty.snap
@@ -13,13 +13,13 @@ expression: ctx.redact_buffer()
  Recent commits                                                                 |
  77cc537 main empty commit                                                      |
  108474f modify instant_fixup.txt                                               |
+▌f05ea1d add instant_fixup.txt                                                  |
 ────────────────────────────────────────────────────────────────────────────────|
 $ git commit --fixup b6eadadbf0b746c00135b317fab80d9801c2d7bb                   |
 [main c0f1150] fixup! modify instant_fixup.txt                                  |
  Author: Author Name <author@email.com>                                         |
  1 file changed, 1 insertion(+), 1 deletion(-)                                  |
-$ git rebase -i --autostash --keep-empty --autosquash b6eadadbf0b746c00135b317fa|
-Rebasing (2/3)Rebasing (3/3)Applied autostash.                                |
-[KSuccessfully rebased and updated refs/heads/main.                           |
+$ git rebase -i -q --autostash --keep-empty --autosquash b6eadadbf0b746c00135b31|
+Applied autostash.                                                              |
 Created autostash: bc5bcfb                                                      |
-styles_hash: 47d1ffca88cf40e0
+styles_hash: e862947c002fddb3


### PR DESCRIPTION
@stackmystack FYI. It seems that when rebasing, skipping `--interactive` when doing `--autosquash` breaks in some versions of Git.
I'm reverting it back to use `GIT_SEQUENCE_EDITOR`!