### PR TITLE
ci: remove '--locked' when installing cargo tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,10 @@ jobs:
     - name: Setup
       run: |
         rustup component add llvm-tools-preview
-        cargo install --locked cargo-deny || true
-        cargo install --locked grcov || true
-        cargo install --locked cargo-machete || true
-        cargo install --locked git-cliff || true
+        cargo install cargo-deny || true
+        cargo install grcov || true
+        cargo install cargo-machete || true
+        cargo install git-cliff || true
 
     - name: make test
       env: 


### PR DESCRIPTION
grcov stopped building with locked deps on the new rust 1.80