### PR TITLE
change priority order of editor envvar lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A help-menu can be shown by pressing the `h` key, or by configuring `general.alw
 <img style="width: 720px" src="vhs/help.png"/>
 
 ### Configuration
-The environment variables `GIT_EDITOR`, `VISUAL` or `EDITOR` (checked in this order) dictate which editor Gitu will open.
+The environment variables `VISUAL`, `EDITOR` or `GIT_EDITOR` (checked in this order) dictate which editor Gitu will open. This means that e. g. commit messages will be opened in the `GIT_EDITOR` by Git, but if the user wishes to do edits to the actual files in a different editor, `VISUAL` or `EDITOR` can be set accordingly.
 
 Configuration is also loaded from:
 - Linux:   `~/.config/gitu/config.toml`

--- a/src/ops/show.rs
+++ b/src/ops/show.rs
@@ -42,7 +42,7 @@ fn editor(file: &Path, maybe_line: Option<u32>) -> Option<Action> {
     let file = file.to_str().unwrap().to_string();
 
     Some(Rc::new(move |state, term| {
-        const EDITOR_VARS: [&str; 3] = ["GIT_EDITOR", "VISUAL", "EDITOR"];
+        const EDITOR_VARS: [&str; 3] = ["VISUAL", "EDITOR", "GIT_EDITOR"];
         let configured_editor = EDITOR_VARS
             .into_iter()
             .find_map(|var| std::env::var(var).ok());


### PR DESCRIPTION
I changed the order of priorities for the lookup of environment variables determining the editor to use for opening files or hunks from the main menu.

It was `GIT_EDITOR`, `VISUAL`, `EDITOR` and I changed it to `VISUAL`, `EDITOR`, `GIT_EDITOR`.

The rationale for this is that one might want to use a different editor for editing e. g. commit messages (which is set by `GIT_EDITOR`) than for opening/editing the changed code, which is what these environment variables are checked for. To allow this any one of `VISUAL` or `EDITOR` should take precedence.

This resolves #246 .

This is my first ever git contribution to another project, I am very sorry if I made any grave mistakes or oversights.