### PR TITLE
Configure/use upstream/pushRemote when pushing and pulling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,12 +334,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,19 +446,6 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-
-[[package]]
-name = "derive_more"
-version = "0.99.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn",
-]
 
 [[package]]
 name = "diff"
@@ -692,7 +673,6 @@ dependencies = [
  "clap",
  "criterion",
  "crossterm 0.27.0",
- "derive_more",
  "etcetera",
  "figment",
  "git-version",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ arboard = { version = "3.4.0", default-features = false, features = [
 chrono = "0.4.38"
 clap = { version = "4.5.16", features = ["derive"] }
 crossterm = "0.27.0"
-derive_more = "0.99.18"
 etcetera = "0.8.0"
 figment = { version = "0.10.19", features = ["toml"] }
 git-version = "0.3.9"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Here's a list of so-far supported features:
 - **Commiting** _(commit, amend, fixup)_
 - **Fetching**
 - **Logging** _(current, other)_
-- **Pulling / Pushing** _(You may want to configure a [push.default](https://git-scm.com/docs/git-config/#Documentation/git-config.txt-pushdefault))_
+- **Pulling / Pushing** _to/from configured upstream/pushDefault_
 - **Rebasing** _(elsewhere, abort, continue, autosquash, interactive)_
 - **Resetting** _(soft, mixed, hard)_
 - **Reverting** _(commit)_

--- a/cliff.toml
+++ b/cliff.toml
@@ -47,18 +47,9 @@ commit_preprocessors = [
 commit_parsers = [
   { message = "^feat", group = "<!-- 0 -->🚀 Features" },
   { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
-  # { message = "^doc", group = "<!-- 3 -->📚 Documentation" },
+  { message = "^config", group = "<!-- 3 -->🔧 Configuration" },
   { message = "^perf", group = "<!-- 4 -->⚡ Performance" },
-  # { message = "^refactor", group = "<!-- 2 -->🚜 Refactor" },
   { message = "^style", group = "<!-- 5 -->🎨 Styling" },
-  # { message = "^test", group = "<!-- 6 -->🧪 Testing" },
-  # { message = "^chore\\(release\\): prepare for", skip = true },
-  # { message = "^chore\\(deps.*\\)", skip = true },
-  # { message = "^chore\\(pr\\)", skip = true },
-  # { message = "^chore\\(pull\\)", skip = true },
-  # { message = "^chore|^ci", group = "<!-- 7 -->⚙️ Miscellaneous Tasks" },
-  { body = ".*security", group = "<!-- 8 -->🛡️ Security" },
-  { message = "^revert", group = "<!-- 9 -->◀️ Revert" },
 ]
 # protect breaking changes from being skipped due to matching a skipping commit_parser
 protect_breaking_commits = false

--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -138,7 +138,7 @@ push_menu.--force = ["-F"]
 push_menu.--no-verify = ["-h"]
 push_menu.--dry-run = ["-n"]
 push_menu.push = ["p"]
-push_menu.push_elsewhere = ["e"]
+push_menu.push_to_elsewhere = ["e"]
 push_menu.quit = ["q", "<esc>"]
 
 root.rebase_menu = ["r"]

--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -129,6 +129,7 @@ log_menu.--grep = ["-F"]
 root.pull_menu = ["F"]
 pull_menu.--rebase = ["-r"]
 pull_menu.pull_from_push_remote = ["p"]
+pull_menu.pull_from_upstream = ["u"]
 pull_menu.pull_from_elsewhere = ["e"]
 pull_menu.quit = ["q", "<esc>"]
 

--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -128,6 +128,7 @@ log_menu.--grep = ["-F"]
 
 root.pull_menu = ["F"]
 pull_menu.--rebase = ["-r"]
+pull_menu.pull_from_push_remote = ["p"]
 pull_menu.pull_from_elsewhere = ["e"]
 pull_menu.quit = ["q", "<esc>"]
 

--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -138,6 +138,7 @@ push_menu.--force-with-lease = ["-f"]
 push_menu.--force = ["-F"]
 push_menu.--no-verify = ["-h"]
 push_menu.--dry-run = ["-n"]
+push_menu.push_to_push_remote = ["p"]
 push_menu.push_to_elsewhere = ["e"]
 push_menu.quit = ["q", "<esc>"]
 

--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -129,7 +129,7 @@ log_menu.--grep = ["-F"]
 root.pull_menu = ["F"]
 pull_menu.--rebase = ["-r"]
 pull_menu.pull = ["p"]
-pull_menu.pull_elsewhere = ["e"]
+pull_menu.pull_from_elsewhere = ["e"]
 pull_menu.quit = ["q", "<esc>"]
 
 root.push_menu = ["P"]

--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -136,7 +136,6 @@ push_menu.--force-with-lease = ["-f"]
 push_menu.--force = ["-F"]
 push_menu.--no-verify = ["-h"]
 push_menu.--dry-run = ["-n"]
-push_menu.push = ["p"]
 push_menu.push_to_elsewhere = ["e"]
 push_menu.quit = ["q", "<esc>"]
 

--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -128,7 +128,6 @@ log_menu.--grep = ["-F"]
 
 root.pull_menu = ["F"]
 pull_menu.--rebase = ["-r"]
-pull_menu.pull = ["p"]
 pull_menu.pull_from_elsewhere = ["e"]
 pull_menu.quit = ["q", "<esc>"]
 

--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -139,6 +139,7 @@ push_menu.--force = ["-F"]
 push_menu.--no-verify = ["-h"]
 push_menu.--dry-run = ["-n"]
 push_menu.push_to_push_remote = ["p"]
+push_menu.push_to_upstream = ["u"]
 push_menu.push_to_elsewhere = ["e"]
 push_menu.quit = ["q", "<esc>"]
 

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod commit;
 pub(crate) mod diff;
 pub(crate) mod merge_status;
 pub(crate) mod rebase_status;
+pub(crate) mod remote;
 
 // TODO Use only plumbing commands
 
@@ -187,4 +188,13 @@ pub(crate) fn show_summary(repo: &Repository, reference: &str) -> Res<Commit> {
         hash: commit.id().to_string(),
         details,
     })
+}
+
+pub(crate) fn get_head(repo: &git2::Repository) -> Res<String> {
+    let head = repo.head()?;
+    if head.is_branch() {
+        Ok(head.name().ok_or("Branch is not valid UTF-8")?.into())
+    } else {
+        Err("Head is not a branch".into())
+    }
 }

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -1,0 +1,106 @@
+use git2::{Branch, Remote, Repository};
+
+use crate::Res;
+
+pub(crate) fn get_upstream(repo: &Repository) -> Res<Option<Branch>> {
+    let r = if repo.head()?.is_branch() {
+        Branch::wrap(repo.head()?)
+    } else {
+        return Err("Head is not a branch".into());
+    };
+    match r.upstream() {
+        Ok(v) => Ok(Some(v)),
+        Err(e) if e.class() == git2::ErrorClass::Config => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// If the branch has an upstream, returns the remote name and branch name in that order.
+/// Returns "." as remote if the current branch has no remote upstream.
+///
+/// Branch references would be used like this (in Magit)
+///
+/// // Remote branch
+/// git … push -v origin feature-branch\:refs/heads/feature-branch
+/// git … pull origin refs/heads/feature-branch
+/// git … rebase --autostash origin/feature-branch
+///
+/// // Local branch
+/// git … push -v . feature-branch\:refs/heads/main
+/// git … pull . refs/heads/main
+/// git … rebase --autostash main
+pub(crate) fn get_upstream_components(repo: &Repository) -> Res<Option<(String, String)>> {
+    let Some(upstream) = get_upstream(repo)? else {
+        return Ok(None);
+    };
+
+    let branch = upstream
+        .get()
+        .shorthand()
+        .ok_or("Branch name not utf-8")?
+        .to_string();
+
+    if upstream.get().is_remote() {
+        let branch_full = upstream.get().name().ok_or("Branch name not utf-8")?;
+        let remote = repo
+            .branch_remote_name(branch_full)?
+            .as_str()
+            .ok_or("Remote name not utf-8")?
+            .to_string();
+
+        let remote_prefix = format!("{}/", remote);
+        Ok(Some((remote, branch.replace(&remote_prefix, ""))))
+    } else {
+        Ok(Some((".".into(), branch)))
+    }
+}
+
+pub(crate) fn get_upstream_shortname(repo: &Repository) -> Res<Option<String>> {
+    let Some(upstream) = get_upstream(repo)? else {
+        return Ok(None);
+    };
+    Ok(Some(
+        upstream
+            .get()
+            .shorthand()
+            .ok_or("Upstream ref not utf-8")?
+            .into(),
+    ))
+}
+
+pub(crate) fn get_push_remote(repo: &Repository) -> Res<Option<String>> {
+    let push_remote_cfg = head_push_remote_cfg(repo)?;
+    let config = repo.config()?;
+    match config.get_string(&push_remote_cfg) {
+        Ok(v) if v.is_empty() => Ok(None),
+        Ok(v) => Ok(Some(v)),
+        Err(e) if e.class() == git2::ErrorClass::Config => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+pub(crate) fn set_push_remote(repo: &Repository, remote: Option<&Remote>) -> Res<()> {
+    let push_remote_cfg = head_push_remote_cfg(repo)?;
+    let mut config = repo.config()?;
+    match remote {
+        None => {
+            config.remove(&push_remote_cfg)?;
+        }
+        Some(remote) => {
+            config.set_str(&push_remote_cfg, remote.name().ok_or("Invalid remote")?)?;
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn head_push_remote_cfg(repo: &Repository) -> Res<String> {
+    let head = repo.head()?;
+    let branch = if head.is_branch() {
+        head.shorthand()
+            .ok_or("Head branch name was not valid UTF-8")?
+    } else {
+        return Err("Head is not a branch".into());
+    };
+    let push_remote_cfg = format!("branch.{branch}.pushRemote");
+    Ok(push_remote_cfg)
+}

--- a/src/ops/checkout.rs
+++ b/src/ops/checkout.rs
@@ -1,6 +1,5 @@
 use super::{create_prompt_with_default, selected_rev, Action, OpTrait};
 use crate::{items::TargetData, menu::arg::Arg, prompt::PromptData, state::State, term::Term, Res};
-use derive_more::Display;
 use std::{process::Command, rc::Rc};
 use tui_prompts::State as _;
 
@@ -8,8 +7,6 @@ pub(crate) fn init_args() -> Vec<Arg> {
     vec![]
 }
 
-#[derive(Display)]
-#[display(fmt = "Checkout branch/revision")]
 pub(crate) struct Checkout;
 impl OpTrait for Checkout {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -19,6 +16,10 @@ impl OpTrait for Checkout {
             selected_rev,
             true,
         ))
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "Checkout branch/revision".into()
     }
 }
 
@@ -33,8 +34,6 @@ fn checkout(state: &mut State, term: &mut Term, rev: &str) -> Res<()> {
     Ok(())
 }
 
-#[derive(Display)]
-#[display(fmt = "Checkout new branch")]
 pub(crate) struct CheckoutNewBranch;
 impl OpTrait for CheckoutNewBranch {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -46,6 +45,10 @@ impl OpTrait for CheckoutNewBranch {
             });
             Ok(())
         }))
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "Checkout new branch".into()
     }
 }
 

--- a/src/ops/commit.rs
+++ b/src/ops/commit.rs
@@ -1,6 +1,5 @@
 use super::{Action, OpTrait};
 use crate::{items::TargetData, menu::arg::Arg, state::State, term::Term};
-use derive_more::Display;
 use std::{
     ffi::{OsStr, OsString},
     process::Command,
@@ -24,8 +23,6 @@ pub(crate) fn init_args() -> Vec<Arg> {
     ]
 }
 
-#[derive(Display)]
-#[display(fmt = "Commit")]
 pub(crate) struct Commit;
 impl OpTrait for Commit {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -39,10 +36,12 @@ impl OpTrait for Commit {
             Ok(())
         }))
     }
+
+    fn display(&self, _state: &State) -> String {
+        "Commit".into()
+    }
 }
 
-#[derive(Display)]
-#[display(fmt = "amend")]
 pub(crate) struct CommitAmend;
 impl OpTrait for CommitAmend {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -56,10 +55,12 @@ impl OpTrait for CommitAmend {
             Ok(())
         }))
     }
+
+    fn display(&self, _state: &State) -> String {
+        "amend".into()
+    }
 }
 
-#[derive(Display)]
-#[display(fmt = "fixup")]
 pub(crate) struct CommitFixup;
 impl OpTrait for CommitFixup {
     fn get_action(&self, target: Option<&TargetData>) -> Option<Action> {
@@ -77,8 +78,13 @@ impl OpTrait for CommitFixup {
             _ => None,
         }
     }
+
     fn is_target_op(&self) -> bool {
         true
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "fixup".into()
     }
 }
 
@@ -90,8 +96,6 @@ fn commit_fixup_cmd(args: &[OsString], rev: &OsStr) -> Command {
     cmd
 }
 
-#[derive(Display)]
-#[display(fmt = "instant fixup")]
 pub(crate) struct CommitInstantFixup;
 impl OpTrait for CommitInstantFixup {
     fn get_action(&self, target: Option<&TargetData>) -> Option<Action> {
@@ -111,8 +115,13 @@ impl OpTrait for CommitInstantFixup {
             _ => None,
         }
     }
+
     fn is_target_op(&self) -> bool {
         true
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "instant fixup".into()
     }
 }
 

--- a/src/ops/copy_hash.rs
+++ b/src/ops/copy_hash.rs
@@ -1,10 +1,7 @@
 use super::{Action, OpTrait};
-use crate::items::TargetData;
-use derive_more::Display;
+use crate::{items::TargetData, state::State};
 use std::rc::Rc;
 
-#[derive(Display)]
-#[display(fmt = "Copy hash")]
 pub(crate) struct CopyHash;
 impl OpTrait for CopyHash {
     fn get_action(&self, target: Option<&TargetData>) -> Option<Action> {
@@ -15,6 +12,10 @@ impl OpTrait for CopyHash {
     }
     fn is_target_op(&self) -> bool {
         true
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "Copy hash".into()
     }
 }
 

--- a/src/ops/discard.rs
+++ b/src/ops/discard.rs
@@ -1,10 +1,7 @@
 use super::{Action, OpTrait};
-use crate::{git::diff::Hunk, items::TargetData};
-use derive_more::Display;
+use crate::{git::diff::Hunk, items::TargetData, state::State};
 use std::{path::PathBuf, process::Command, rc::Rc};
 
-#[derive(Display)]
-#[display(fmt = "Discard")]
 pub(crate) struct Discard;
 impl OpTrait for Discard {
     fn get_action(&self, target: Option<&TargetData>) -> Option<Action> {
@@ -25,6 +22,10 @@ impl OpTrait for Discard {
 
     fn is_target_op(&self) -> bool {
         true
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "Discard".into()
     }
 }
 

--- a/src/ops/editor.rs
+++ b/src/ops/editor.rs
@@ -7,11 +7,8 @@ use crate::{
     term::Term,
     Res,
 };
-use derive_more::Display;
 use std::rc::Rc;
 
-#[derive(Display)]
-#[display(fmt = "Quit/Close")]
 pub(crate) struct Quit;
 impl OpTrait for Quit {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -49,10 +46,12 @@ impl OpTrait for Quit {
             Ok(())
         }))
     }
+
+    fn display(&self, _state: &State) -> String {
+        "Quit/Close".into()
+    }
 }
 
-#[derive(Display)]
-#[display(fmt = "Submenu")]
 pub(crate) struct OpenMenu(pub crate::menu::Menu);
 impl OpTrait for OpenMenu {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -62,10 +61,12 @@ impl OpTrait for OpenMenu {
             Ok(())
         }))
     }
+
+    fn display(&self, _state: &State) -> String {
+        "Submenu".into()
+    }
 }
 
-#[derive(Display)]
-#[display(fmt = "Refresh")]
 pub(crate) struct Refresh;
 impl OpTrait for Refresh {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -74,10 +75,12 @@ impl OpTrait for Refresh {
             state.screen_mut().update()
         }))
     }
+
+    fn display(&self, _state: &State) -> String {
+        "Refresh".into()
+    }
 }
 
-#[derive(Display)]
-#[display(fmt = .0)]
 pub(crate) struct ToggleArg(pub String);
 impl OpTrait for ToggleArg {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -119,6 +122,10 @@ impl OpTrait for ToggleArg {
             Ok(())
         }))
     }
+
+    fn display(&self, _state: &State) -> String {
+        self.0.clone()
+    }
 }
 
 fn parse_and_set_arg(state: &mut State, _term: &mut Term, value: &str, arg: &String) -> Res<()> {
@@ -132,8 +139,6 @@ fn parse_and_set_arg(state: &mut State, _term: &mut Term, value: &str, arg: &Str
     Ok(())
 }
 
-#[derive(Display)]
-#[display(fmt = "Toggle section")]
 pub(crate) struct ToggleSection;
 impl OpTrait for ToggleSection {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -143,10 +148,12 @@ impl OpTrait for ToggleSection {
             Ok(())
         }))
     }
+
+    fn display(&self, _state: &State) -> String {
+        "Toggle section".into()
+    }
 }
 
-#[derive(Display)]
-#[display(fmt = "Up")]
 pub(crate) struct MoveUp;
 impl OpTrait for MoveUp {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -156,10 +163,12 @@ impl OpTrait for MoveUp {
             Ok(())
         }))
     }
+
+    fn display(&self, _state: &State) -> String {
+        "Up".into()
+    }
 }
 
-#[derive(Display)]
-#[display(fmt = "Down")]
 pub(crate) struct MoveDown;
 impl OpTrait for MoveDown {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -169,10 +178,12 @@ impl OpTrait for MoveDown {
             Ok(())
         }))
     }
+
+    fn display(&self, _state: &State) -> String {
+        "Down".into()
+    }
 }
 
-#[derive(Display)]
-#[display(fmt = "Down line")]
 pub(crate) struct MoveDownLine;
 impl OpTrait for MoveDownLine {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -182,10 +193,12 @@ impl OpTrait for MoveDownLine {
             Ok(())
         }))
     }
+
+    fn display(&self, _state: &State) -> String {
+        "Down line".into()
+    }
 }
 
-#[derive(Display)]
-#[display(fmt = "Up line")]
 pub(crate) struct MoveUpLine;
 impl OpTrait for MoveUpLine {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -197,10 +210,12 @@ impl OpTrait for MoveUpLine {
             Ok(())
         }))
     }
+
+    fn display(&self, _state: &State) -> String {
+        "Up line".into()
+    }
 }
 
-#[derive(Display)]
-#[display(fmt = "Next section")]
 pub(crate) struct MoveNextSection;
 impl OpTrait for MoveNextSection {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -211,10 +226,12 @@ impl OpTrait for MoveNextSection {
             Ok(())
         }))
     }
+
+    fn display(&self, _state: &State) -> String {
+        "Next section".into()
+    }
 }
 
-#[derive(Display)]
-#[display(fmt = "Prev section")]
 pub(crate) struct MovePrevSection;
 impl OpTrait for MovePrevSection {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -227,10 +244,12 @@ impl OpTrait for MovePrevSection {
             Ok(())
         }))
     }
+
+    fn display(&self, _state: &State) -> String {
+        "Prev section".into()
+    }
 }
 
-#[derive(Display)]
-#[display(fmt = "Parent section")]
 pub(crate) struct MoveParentSection;
 impl OpTrait for MoveParentSection {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -243,10 +262,12 @@ impl OpTrait for MoveParentSection {
             Ok(())
         }))
     }
+
+    fn display(&self, _state: &State) -> String {
+        "Parent section".into()
+    }
 }
 
-#[derive(Display)]
-#[display(fmt = "Half page up")]
 pub(crate) struct HalfPageUp;
 impl OpTrait for HalfPageUp {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -256,10 +277,12 @@ impl OpTrait for HalfPageUp {
             Ok(())
         }))
     }
+
+    fn display(&self, _state: &State) -> String {
+        "Half page up".into()
+    }
 }
 
-#[derive(Display)]
-#[display(fmt = "Half page down")]
 pub(crate) struct HalfPageDown;
 impl OpTrait for HalfPageDown {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -268,5 +291,9 @@ impl OpTrait for HalfPageDown {
             state.screen_mut().scroll_half_page_down();
             Ok(())
         }))
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "Half page down".into()
     }
 }

--- a/src/ops/fetch.rs
+++ b/src/ops/fetch.rs
@@ -1,6 +1,5 @@
 use super::{create_prompt, Action, OpTrait};
 use crate::{items::TargetData, menu::arg::Arg, state::State, term::Term, Res};
-use derive_more::Display;
 use std::{process::Command, rc::Rc};
 
 pub(crate) fn init_args() -> Vec<Arg> {
@@ -10,8 +9,6 @@ pub(crate) fn init_args() -> Vec<Arg> {
     ]
 }
 
-#[derive(Display)]
-#[display(fmt = "from all remotes")]
 pub(crate) struct FetchAll;
 impl OpTrait for FetchAll {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -25,14 +22,20 @@ impl OpTrait for FetchAll {
             Ok(())
         }))
     }
+
+    fn display(&self, _state: &State) -> String {
+        "from all remotes".into()
+    }
 }
 
-#[derive(Display)]
-#[display(fmt = "from elsewhere")]
 pub(crate) struct FetchElsewhere;
 impl OpTrait for FetchElsewhere {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
         Some(create_prompt("Select remote", push_elsewhere, true))
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "from elsewhere".into()
     }
 }
 

--- a/src/ops/log.rs
+++ b/src/ops/log.rs
@@ -7,7 +7,6 @@ use crate::{
     term::Term,
     Res,
 };
-use derive_more::Display;
 use git2::Oid;
 use regex::Regex;
 use std::rc::Rc;
@@ -25,8 +24,6 @@ pub(crate) fn init_args() -> Vec<Arg> {
     ]
 }
 
-#[derive(Display)]
-#[display(fmt = "current")]
 pub(crate) struct LogCurrent;
 impl OpTrait for LogCurrent {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -35,10 +32,12 @@ impl OpTrait for LogCurrent {
             Ok(())
         }))
     }
+
+    fn display(&self, _state: &State) -> String {
+        "current".into()
+    }
 }
 
-#[derive(Display)]
-#[display(fmt = "other")]
 pub(crate) struct LogOther;
 impl OpTrait for LogOther {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -48,6 +47,10 @@ impl OpTrait for LogOther {
             selected_rev,
             true,
         ))
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "other".into()
     }
 }
 

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -27,7 +27,7 @@ pub(crate) mod unstage;
 
 pub(crate) type Action = Rc<dyn FnMut(&mut State, &mut Term) -> Res<()>>;
 
-pub(crate) trait OpTrait: Display {
+pub(crate) trait OpTrait {
     /// Get the implementation (which may or may not exist) of the Op given some TargetData.
     /// This indirection allows Gitu to show a contextual menu of applicable actions.
     fn get_action(&self, target: Option<&TargetData>) -> Option<Action>;
@@ -37,6 +37,8 @@ pub(crate) trait OpTrait: Display {
     fn is_target_op(&self) -> bool {
         false
     }
+
+    fn display(&self, state: &State) -> String;
 }
 
 #[derive(Clone, PartialOrd, Ord, PartialEq, Eq, Debug, Serialize, Deserialize)]
@@ -49,10 +51,12 @@ pub(crate) enum Op {
     FetchAll,
     FetchElsewhere,
     LogCurrent,
-    Pull,
-    PullElsewhere,
-    Push,
-    PushElsewhere,
+    PullFromPushRemote,
+    PullFromUpstream,
+    PullFromElsewhere,
+    PushToPushRemote,
+    PushToUpstream,
+    PushToElsewhere,
     RebaseAbort,
     RebaseContinue,
     RebaseElsewhere,
@@ -127,10 +131,12 @@ impl Op {
             Op::FetchAll => Box::new(fetch::FetchAll),
             Op::FetchElsewhere => Box::new(fetch::FetchElsewhere),
             Op::LogCurrent => Box::new(log::LogCurrent),
-            Op::Pull => Box::new(pull::Pull),
-            Op::PullElsewhere => Box::new(pull::PullElsewhere),
-            Op::Push => Box::new(push::Push),
-            Op::PushElsewhere => Box::new(push::PushElsewhere),
+            Op::PullFromPushRemote => Box::new(pull::PullFromPushRemote),
+            Op::PullFromUpstream => Box::new(pull::PullFromUpstream),
+            Op::PullFromElsewhere => Box::new(pull::PullFromElsewhere),
+            Op::PushToPushRemote => Box::new(push::PushToPushRemote),
+            Op::PushToUpstream => Box::new(push::PushToUpstream),
+            Op::PushToElsewhere => Box::new(push::PushToElsewhere),
             Op::RebaseAbort => Box::new(rebase::RebaseAbort),
             Op::RebaseContinue => Box::new(rebase::RebaseContinue),
             Op::RebaseElsewhere => Box::new(rebase::RebaseElsewhere),

--- a/src/ops/pull.rs
+++ b/src/ops/pull.rs
@@ -1,43 +1,121 @@
 use super::{create_prompt, Action, OpTrait};
-use crate::{items::TargetData, menu::arg::Arg, state::State, term::Term, Res};
-use derive_more::Display;
+use crate::{
+    git::{
+        self,
+        remote::{self, get_push_remote, get_upstream_components, get_upstream_shortname},
+    },
+    items::TargetData,
+    menu::arg::Arg,
+    state::State,
+    term::Term,
+    Res,
+};
 use std::{process::Command, rc::Rc};
 
 pub(crate) fn init_args() -> Vec<Arg> {
     vec![Arg::new_flag("--rebase", "Rebase local commits", false)]
 }
 
-#[derive(Display)]
-#[display(fmt = "from default")]
-pub(crate) struct Pull;
-impl OpTrait for Pull {
+pub(crate) struct PullFromPushRemote;
+impl OpTrait for PullFromPushRemote {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
-        Some(Rc::new(|state: &mut State, term: &mut Term| {
-            let mut cmd = Command::new("git");
-            cmd.arg("pull");
-            cmd.args(state.pending_menu.as_ref().unwrap().args());
+        Some(Rc::new(
+            |state: &mut State, term: &mut Term| match get_push_remote(&state.repo)? {
+                None => {
+                    let mut prompt =
+                        create_prompt("Set pushRemote then pull", set_push_remote_and_pull, true);
+                    Rc::get_mut(&mut prompt).unwrap()(state, term)
+                }
+                Some(push_remote) => {
+                    let refspec = git::get_head(&state.repo)?;
+                    pull(state, term, &[&push_remote, &refspec])
+                }
+            },
+        ))
+    }
 
-            state.close_menu();
-            state.run_cmd_async(term, &[], cmd)?;
-            Ok(())
-        }))
+    fn display(&self, state: &State) -> String {
+        match get_push_remote(&state.repo) {
+            Ok(Some(remote)) => format!("from {}", remote),
+            Ok(None) => "pushRemote, setting that".into(),
+            Err(e) => format!("error: {}", e),
+        }
     }
 }
 
-#[derive(Display)]
-#[display(fmt = "from elsewhere")]
-pub(crate) struct PullElsewhere;
-impl OpTrait for PullElsewhere {
+fn set_push_remote_and_pull(state: &mut State, term: &mut Term, push_remote_name: &str) -> Res<()> {
+    let repo = state.repo.clone();
+    let push_remote = repo
+        .find_remote(push_remote_name)
+        .map_err(|_| "Invalid pushRemote")?;
+
+    remote::set_push_remote(&repo, Some(&push_remote))
+        .map_err(|_| "Could not set pushRemote config")?;
+
+    let refspec = git::get_head(&repo)?;
+    pull(state, term, &[push_remote_name, &refspec])
+}
+
+pub(crate) struct PullFromUpstream;
+impl OpTrait for PullFromUpstream {
+    fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
+        Some(Rc::new(
+            |state: &mut State, term: &mut Term| match get_upstream_components(&state.repo)? {
+                None => {
+                    let mut prompt =
+                        create_prompt("Set upstream then pull", set_upstream_and_pull, true);
+                    Rc::get_mut(&mut prompt).unwrap()(state, term)
+                }
+                Some((remote, branch)) => {
+                    let refspec = format!("refs/heads/{}", branch);
+                    pull(state, term, &[&remote, &refspec])
+                }
+            },
+        ))
+    }
+
+    fn display(&self, state: &State) -> String {
+        match get_upstream_shortname(&state.repo) {
+            Ok(Some(upstream)) => format!("from {}", upstream),
+            Ok(None) => "upstream, setting that".into(),
+            Err(e) => format!("error: {}", e),
+        }
+    }
+}
+
+fn set_upstream_and_pull(state: &mut State, term: &mut Term, upstream_name: &str) -> Res<()> {
+    let mut cmd = Command::new("git");
+    cmd.args(["branch", "--set-upstream-to", upstream_name]);
+    state.run_cmd(term, &[], cmd)?;
+
+    let Some((remote, branch)) = get_upstream_components(&state.repo)? else {
+        return Ok(());
+    };
+
+    let refspec = format!("refs/heads/{}", branch);
+    pull(state, term, &[&remote, &refspec])
+}
+
+pub(crate) struct PullFromElsewhere;
+impl OpTrait for PullFromElsewhere {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
         Some(create_prompt("Select remote", pull_elsewhere, true))
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "from elsewhere".into()
     }
 }
 
 fn pull_elsewhere(state: &mut State, term: &mut Term, remote: &str) -> Res<()> {
+    pull(state, term, &[remote])
+}
+
+fn pull(state: &mut State, term: &mut Term, extra_args: &[&str]) -> Res<()> {
     let mut cmd = Command::new("git");
     cmd.args(["pull"]);
     cmd.args(state.pending_menu.as_ref().unwrap().args());
-    cmd.arg(remote);
+    cmd.args(extra_args);
 
     state.close_menu();
     state.run_cmd_async(term, &[], cmd)?;

--- a/src/ops/push.rs
+++ b/src/ops/push.rs
@@ -1,6 +1,9 @@
 use super::{create_prompt, Action, OpTrait};
+use crate::git;
+use crate::git::remote::{
+    get_push_remote, get_upstream_components, get_upstream_shortname, set_push_remote,
+};
 use crate::{items::TargetData, menu::arg::Arg, state::State, term::Term, Res};
-use derive_more::Display;
 use std::{process::Command, rc::Rc};
 
 pub(crate) fn init_args() -> Vec<Arg> {
@@ -12,37 +15,110 @@ pub(crate) fn init_args() -> Vec<Arg> {
     ]
 }
 
-#[derive(Display)]
-#[display(fmt = "to default")]
-pub(crate) struct Push;
-impl OpTrait for Push {
+pub(crate) struct PushToPushRemote;
+impl OpTrait for PushToPushRemote {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
-        Some(Rc::new(|state: &mut State, term: &mut Term| {
-            let mut cmd = Command::new("git");
-            cmd.args(["push"]);
-            cmd.args(state.pending_menu.as_ref().unwrap().args());
+        Some(Rc::new(
+            |state: &mut State, term: &mut Term| match get_push_remote(&state.repo)? {
+                None => {
+                    let mut prompt =
+                        create_prompt("Set pushRemote then push", set_push_remote_and_push, true);
+                    Rc::get_mut(&mut prompt).unwrap()(state, term)
+                }
+                Some(push_remote) => {
+                    let head_ref = git::get_head(&state.repo)?;
+                    let refspec = format!("{0}:{0}", head_ref);
+                    push(state, term, &[&push_remote, &refspec])
+                }
+            },
+        ))
+    }
 
-            state.close_menu();
-            state.run_cmd_async(term, &[], cmd)?;
-            Ok(())
-        }))
+    fn display(&self, state: &State) -> String {
+        match get_push_remote(&state.repo) {
+            Ok(Some(remote)) => format!("to {}", remote),
+            Ok(None) => "pushRemote, setting that".into(),
+            Err(e) => format!("error: {}", e),
+        }
     }
 }
 
-#[derive(Display)]
-#[display(fmt = "to elsewhere")]
-pub(crate) struct PushElsewhere;
-impl OpTrait for PushElsewhere {
+fn set_push_remote_and_push(state: &mut State, term: &mut Term, push_remote_name: &str) -> Res<()> {
+    let repo = state.repo.clone();
+    let push_remote = repo
+        .find_remote(push_remote_name)
+        .map_err(|_| "Invalid pushRemote")?;
+
+    // TODO Would be nice to have the command visible in the log. Resort to `git config`?
+    set_push_remote(&repo, Some(&push_remote)).map_err(|_| "Could not set pushRemote config")?;
+
+    let head_ref = git::get_head(&state.repo)?;
+    let refspec = format!("{0}:{0}", head_ref);
+    push(state, term, &[push_remote_name, &refspec])
+}
+
+pub(crate) struct PushToUpstream;
+impl OpTrait for PushToUpstream {
+    fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
+        Some(Rc::new(
+            |state: &mut State, term: &mut Term| match get_upstream_components(&state.repo)? {
+                None => {
+                    let mut prompt =
+                        create_prompt("Set upstream then push", set_upstream_and_push, true);
+                    Rc::get_mut(&mut prompt).unwrap()(state, term)
+                }
+                Some((remote, branch)) => push_head_to(state, term, &remote, &branch),
+            },
+        ))
+    }
+
+    fn display(&self, state: &State) -> String {
+        match get_upstream_shortname(&state.repo) {
+            Ok(Some(upstream)) => format!("to {}", upstream),
+            Ok(None) => "upstream, setting that".into(),
+            Err(e) => format!("error: {}", e),
+        }
+    }
+}
+
+fn set_upstream_and_push(state: &mut State, term: &mut Term, upstream_name: &str) -> Res<()> {
+    let mut cmd = Command::new("git");
+    cmd.args(["branch", "--set-upstream-to", upstream_name]);
+    state.run_cmd(term, &[], cmd)?;
+
+    let Some((remote, branch)) = get_upstream_components(&state.repo)? else {
+        return Ok(());
+    };
+
+    push_head_to(state, term, &remote, &branch)
+}
+
+pub(crate) struct PushToElsewhere;
+impl OpTrait for PushToElsewhere {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
         Some(create_prompt("Select remote", push_elsewhere, true))
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "to elsewhere".into()
     }
 }
 
 fn push_elsewhere(state: &mut State, term: &mut Term, remote: &str) -> Res<()> {
+    push(state, term, &[remote])
+}
+
+fn push_head_to(state: &mut State, term: &mut Term, remote: &str, branch: &str) -> Res<()> {
+    let head_ref = git::get_head(&state.repo)?;
+    let refspec = format!("{}:refs/heads/{}", head_ref, branch);
+    push(state, term, &[remote, &refspec])
+}
+
+fn push(state: &mut State, term: &mut Term, extra_args: &[&str]) -> Res<()> {
     let mut cmd = Command::new("git");
     cmd.args(["push"]);
-    cmd.arg(format!("--repo={}", remote));
     cmd.args(state.pending_menu.as_ref().unwrap().args());
+    cmd.args(extra_args);
 
     state.close_menu();
     state.run_cmd_async(term, &[], cmd)?;

--- a/src/ops/rebase.rs
+++ b/src/ops/rebase.rs
@@ -1,6 +1,5 @@
 use super::{create_prompt_with_default, selected_rev, Action, OpTrait};
 use crate::{items::TargetData, menu::arg::Arg, state::State, term::Term, Res};
-use derive_more::Display;
 use std::{
     ffi::{OsStr, OsString},
     process::Command,
@@ -23,8 +22,6 @@ pub(crate) fn init_args() -> Vec<Arg> {
     ]
 }
 
-#[derive(Display)]
-#[display(fmt = "continue")]
 pub(crate) struct RebaseContinue;
 impl OpTrait for RebaseContinue {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -37,10 +34,12 @@ impl OpTrait for RebaseContinue {
             Ok(())
         }))
     }
+
+    fn display(&self, _state: &State) -> String {
+        "continue".into()
+    }
 }
 
-#[derive(Display)]
-#[display(fmt = "abort")]
 pub(crate) struct RebaseAbort;
 impl OpTrait for RebaseAbort {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -53,10 +52,12 @@ impl OpTrait for RebaseAbort {
             Ok(())
         }))
     }
+
+    fn display(&self, _state: &State) -> String {
+        "abort".into()
+    }
 }
 
-#[derive(Display)]
-#[display(fmt = "onto elsewhere")]
 pub(crate) struct RebaseElsewhere;
 impl OpTrait for RebaseElsewhere {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -66,6 +67,10 @@ impl OpTrait for RebaseElsewhere {
             selected_rev,
             true,
         ))
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "onto elsewhere".into()
     }
 }
 
@@ -80,8 +85,6 @@ fn rebase_elsewhere(state: &mut State, term: &mut Term, rev: &str) -> Res<()> {
     Ok(())
 }
 
-#[derive(Display)]
-#[display(fmt = "interactively")]
 pub(crate) struct RebaseInteractive;
 impl OpTrait for RebaseInteractive {
     fn get_action(&self, target: Option<&TargetData>) -> Option<Action> {
@@ -102,6 +105,10 @@ impl OpTrait for RebaseInteractive {
     fn is_target_op(&self) -> bool {
         true
     }
+
+    fn display(&self, _state: &State) -> String {
+        "interactively".into()
+    }
 }
 
 fn rebase_interactive_cmd(args: &[OsString], rev: &OsStr) -> Command {
@@ -118,8 +125,6 @@ fn parent(reference: &OsStr) -> OsString {
     parent
 }
 
-#[derive(Display)]
-#[display(fmt = "autosquash")]
 pub(crate) struct RebaseAutosquash;
 impl OpTrait for RebaseAutosquash {
     fn get_action(&self, target: Option<&TargetData>) -> Option<Action> {
@@ -139,6 +144,10 @@ impl OpTrait for RebaseAutosquash {
     }
     fn is_target_op(&self) -> bool {
         true
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "autosquash".into()
     }
 }
 

--- a/src/ops/reset.rs
+++ b/src/ops/reset.rs
@@ -1,14 +1,11 @@
 use super::{create_prompt_with_default, selected_rev, OpTrait};
 use crate::{items::TargetData, menu::arg::Arg, state::State, term::Term, Action, Res};
-use derive_more::Display;
 use std::process::Command;
 
 pub(crate) fn init_args() -> Vec<Arg> {
     vec![]
 }
 
-#[derive(Display)]
-#[display(fmt = "soft")]
 pub(crate) struct ResetSoft;
 impl OpTrait for ResetSoft {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -18,6 +15,10 @@ impl OpTrait for ResetSoft {
             selected_rev,
             true,
         ))
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "soft".into()
     }
 }
 
@@ -31,8 +32,6 @@ fn reset_soft(state: &mut State, term: &mut Term, input: &str) -> Res<()> {
     state.run_cmd(term, &[], cmd)
 }
 
-#[derive(Display)]
-#[display(fmt = "mixed")]
 pub(crate) struct ResetMixed;
 impl OpTrait for ResetMixed {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -42,6 +41,10 @@ impl OpTrait for ResetMixed {
             selected_rev,
             true,
         ))
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "mixed".into()
     }
 }
 
@@ -55,8 +58,6 @@ fn reset_mixed(state: &mut State, term: &mut Term, input: &str) -> Res<()> {
     state.run_cmd(term, &[], cmd)
 }
 
-#[derive(Display)]
-#[display(fmt = "hard")]
 pub(crate) struct ResetHard;
 impl OpTrait for ResetHard {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -66,6 +67,10 @@ impl OpTrait for ResetHard {
             selected_rev,
             true,
         ))
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "hard".into()
     }
 }
 

--- a/src/ops/revert.rs
+++ b/src/ops/revert.rs
@@ -1,7 +1,6 @@
 use std::{process::Command, rc::Rc};
 
 use crate::{items::TargetData, menu::arg::Arg, state::State, term::Term, Res};
-use derive_more::*;
 
 use super::{create_prompt_with_default, selected_rev, Action, OpTrait};
 
@@ -14,8 +13,6 @@ pub(crate) fn init_args() -> Vec<Arg> {
     ]
 }
 
-#[derive(Display)]
-#[display(fmt = "Abort")]
 pub(crate) struct RevertAbort;
 impl OpTrait for RevertAbort {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -28,10 +25,12 @@ impl OpTrait for RevertAbort {
             Ok(())
         }))
     }
+
+    fn display(&self, _state: &State) -> String {
+        "Abort".into()
+    }
 }
 
-#[derive(Display)]
-#[display(fmt = "Continue")]
 pub(crate) struct RevertContinue;
 impl OpTrait for RevertContinue {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -44,10 +43,12 @@ impl OpTrait for RevertContinue {
             Ok(())
         }))
     }
+
+    fn display(&self, _state: &State) -> String {
+        "Continue".into()
+    }
 }
 
-#[derive(Display)]
-#[display(fmt = "Revert commit(s)")]
 pub(crate) struct RevertCommit;
 impl OpTrait for RevertCommit {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -57,6 +58,10 @@ impl OpTrait for RevertCommit {
             selected_rev,
             true,
         ))
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "Revert commit(s)".into()
     }
 }
 

--- a/src/ops/show.rs
+++ b/src/ops/show.rs
@@ -1,10 +1,7 @@
 use super::OpTrait;
-use crate::{items::TargetData, screen, Action};
-use derive_more::Display;
+use crate::{items::TargetData, screen, state::State, Action};
 use std::{path::Path, process::Command, rc::Rc};
 
-#[derive(Default, Clone, Copy, Debug, Display)]
-#[display(fmt = "Show")]
 pub(crate) struct Show;
 impl OpTrait for Show {
     fn get_action(&self, target: Option<&TargetData>) -> Option<Action> {
@@ -19,6 +16,10 @@ impl OpTrait for Show {
     }
     fn is_target_op(&self) -> bool {
         true
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "Show".into()
     }
 }
 

--- a/src/ops/show_refs.rs
+++ b/src/ops/show_refs.rs
@@ -1,10 +1,7 @@
 use super::{Action, OpTrait};
 use crate::{items::TargetData, screen, state::State, term::Term};
-use derive_more::Display;
 use std::rc::Rc;
 
-#[derive(Display)]
-#[display(fmt = "Show Refs")]
 pub(crate) struct ShowRefs;
 impl OpTrait for ShowRefs {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -12,6 +9,10 @@ impl OpTrait for ShowRefs {
             goto_refs_screen(state);
             Ok(())
         }))
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "Show Refs".into()
     }
 }
 

--- a/src/ops/stage.rs
+++ b/src/ops/stage.rs
@@ -6,11 +6,8 @@ use crate::{
     term::Term,
     Action,
 };
-use derive_more::Display;
 use std::{ffi::OsString, process::Command, rc::Rc};
 
-#[derive(Display)]
-#[display(fmt = "Stage")]
 pub(crate) struct Stage;
 impl OpTrait for Stage {
     fn get_action(&self, target: Option<&TargetData>) -> Option<Action> {
@@ -26,8 +23,13 @@ impl OpTrait for Stage {
 
         Some(action)
     }
+
     fn is_target_op(&self) -> bool {
         true
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "Stage".into()
     }
 }
 

--- a/src/ops/stash.rs
+++ b/src/ops/stash.rs
@@ -1,6 +1,5 @@
 use super::{create_prompt, create_prompt_with_default, Action, OpTrait};
 use crate::{items::TargetData, menu::arg::Arg, state::State, term::Term, Res};
-use derive_more::Display;
 use git2::{Repository, Status, StatusOptions};
 use std::{process::Command, rc::Rc};
 
@@ -11,12 +10,14 @@ pub(crate) fn init_args() -> Vec<Arg> {
     ]
 }
 
-#[derive(Display)]
-#[display(fmt = "both")]
 pub(crate) struct Stash;
 impl OpTrait for Stash {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
         Some(create_prompt("Stash message", stash_push, true))
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "both".into()
     }
 }
 
@@ -33,12 +34,14 @@ fn stash_push(state: &mut State, term: &mut Term, input: &str) -> Res<()> {
     Ok(())
 }
 
-#[derive(Display)]
-#[display(fmt = "index")]
 pub(crate) struct StashIndex;
 impl OpTrait for StashIndex {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
         Some(create_prompt("Stash message", stash_push_index, true))
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "index".into()
     }
 }
 
@@ -55,8 +58,6 @@ fn stash_push_index(state: &mut State, term: &mut Term, input: &str) -> Res<()> 
     Ok(())
 }
 
-#[derive(Display)]
-#[display(fmt = "worktree")]
 pub(crate) struct StashWorktree;
 impl OpTrait for StashWorktree {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -70,6 +71,10 @@ impl OpTrait for StashWorktree {
             Rc::get_mut(&mut create_prompt).unwrap()(state, term)?;
             Ok(())
         }))
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "worktree".into()
     }
 }
 
@@ -140,12 +145,14 @@ fn is_something_staged(repo: &Repository) -> Res<bool> {
     }))
 }
 
-#[derive(Display)]
-#[display(fmt = "keeping index")]
 pub(crate) struct StashKeepIndex;
 impl OpTrait for StashKeepIndex {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
         Some(create_prompt("Stash message", stash_push_keep_index, true))
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "keeping index".into()
     }
 }
 
@@ -162,8 +169,6 @@ fn stash_push_keep_index(state: &mut State, term: &mut Term, input: &str) -> Res
     Ok(())
 }
 
-#[derive(Display)]
-#[display(fmt = "pop")]
 pub(crate) struct StashPop;
 impl OpTrait for StashPop {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -173,6 +178,10 @@ impl OpTrait for StashPop {
             selected_stash,
             true,
         ))
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "pop".into()
     }
 }
 
@@ -186,8 +195,6 @@ fn stash_pop(state: &mut State, term: &mut Term, input: &str) -> Res<()> {
     Ok(())
 }
 
-#[derive(Display)]
-#[display(fmt = "apply")]
 pub(crate) struct StashApply;
 impl OpTrait for StashApply {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -197,6 +204,10 @@ impl OpTrait for StashApply {
             selected_stash,
             true,
         ))
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "apply".into()
     }
 }
 
@@ -210,8 +221,6 @@ fn stash_apply(state: &mut State, term: &mut Term, input: &str) -> Res<()> {
     Ok(())
 }
 
-#[derive(Display)]
-#[display(fmt = "drop")]
 pub(crate) struct StashDrop;
 impl OpTrait for StashDrop {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
@@ -221,6 +230,10 @@ impl OpTrait for StashDrop {
             selected_stash,
             true,
         ))
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "drop".into()
     }
 }
 

--- a/src/ops/unstage.rs
+++ b/src/ops/unstage.rs
@@ -1,10 +1,7 @@
 use super::OpTrait;
 use crate::{git::diff::PatchMode, items::TargetData, state::State, term::Term, Action};
-use derive_more::Display;
 use std::{ffi::OsString, process::Command, rc::Rc};
 
-#[derive(Display)]
-#[display(fmt = "Unstage")]
 pub(crate) struct Unstage;
 impl OpTrait for Unstage {
     fn get_action(&self, target: Option<&TargetData>) -> Option<Action> {
@@ -23,6 +20,10 @@ impl OpTrait for Unstage {
     }
     fn is_target_op(&self) -> bool {
         true
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "Unstage".into()
     }
 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -12,6 +12,7 @@ mod pull;
 mod push;
 mod quit;
 mod rebase;
+mod remote;
 mod reset;
 mod stage;
 mod stash;
@@ -199,13 +200,6 @@ fn fetch_all() {
     let ctx = TestContext::setup_clone();
     clone_and_commit(&ctx.remote_dir, "remote-file", "hello");
     snapshot!(ctx, "fa");
-}
-
-#[test]
-fn pull() {
-    let ctx = TestContext::setup_clone();
-    clone_and_commit(&ctx.remote_dir, "remote-file", "hello");
-    snapshot!(ctx, "Fp");
 }
 
 mod show_refs {

--- a/src/tests/pull.rs
+++ b/src/tests/pull.rs
@@ -1,6 +1,74 @@
 use super::*;
 
 #[test]
+fn pull_menu_no_remote_or_upstream_set() {
+    let ctx = TestContext::setup_clone();
+    run(ctx.dir.path(), &["git", "branch", "--unset-upstream"]);
+    snapshot!(ctx, "F");
+}
+
+#[test]
+fn pull_menu_existing_push_remote_and_upstream() {
+    let ctx = TestContext::setup_clone();
+    run(
+        ctx.dir.path(),
+        &["git", "config", "branch.main.pushRemote", "origin"],
+    );
+    snapshot!(ctx, "F");
+}
+
+#[test]
+fn pull_upstream() {
+    let ctx = TestContext::setup_clone();
+    clone_and_commit(&ctx.remote_dir, "remote-file", "hello");
+    snapshot!(ctx, "Fu");
+}
+
+#[test]
+fn pull_push_remote() {
+    let ctx = TestContext::setup_clone();
+    run(
+        ctx.dir.path(),
+        &["git", "config", "branch.main.pushRemote", "origin"],
+    );
+
+    snapshot!(ctx, "Fp");
+}
+
+#[test]
+fn pull_upstream_prompt() {
+    let ctx = TestContext::setup_clone();
+    run(ctx.dir.path(), &["git", "branch", "--unset-upstream"]);
+    snapshot!(ctx, "Fu");
+}
+
+#[test]
+fn pull_push_remote_prompt() {
+    let ctx = TestContext::setup_clone();
+    snapshot!(ctx, "Fp");
+}
+
+#[test]
+fn pull_setup_upstream() {
+    let ctx = TestContext::setup_clone();
+    run(ctx.dir.path(), &["git", "checkout", "-b", "new-branch"]);
+    snapshot!(ctx, "Fumain<enter>F");
+}
+
+#[test]
+fn pull_setup_upstream_same_as_head() {
+    let ctx = TestContext::setup_clone();
+    run(ctx.dir.path(), &["git", "checkout", "-b", "new-branch"]);
+    snapshot!(ctx, "Funew-branch<enter>");
+}
+
+#[test]
+fn pull_setup_push_remote() {
+    let ctx = TestContext::setup_clone();
+    snapshot!(ctx, "Fporigin<enter>F");
+}
+
+#[test]
 fn pull_from_elsewhere_prompt() {
     snapshot!(TestContext::setup_clone(), "Fe");
 }

--- a/src/tests/push.rs
+++ b/src/tests/push.rs
@@ -1,17 +1,81 @@
 use super::*;
 
 #[test]
-fn push() {
+fn push_menu_no_remote_or_upstream_set() {
+    let ctx = TestContext::setup_clone();
+    run(ctx.dir.path(), &["git", "branch", "--unset-upstream"]);
+    snapshot!(ctx, "P");
+}
+
+#[test]
+fn push_menu_existing_push_remote_and_upstream() {
+    let ctx = TestContext::setup_clone();
+    run(
+        ctx.dir.path(),
+        &["git", "config", "branch.main.pushRemote", "origin"],
+    );
+    snapshot!(ctx, "P");
+}
+
+#[test]
+fn push_upstream() {
+    let ctx = TestContext::setup_clone();
+    commit(ctx.dir.path(), "new-file", "");
+    snapshot!(ctx, "Pu");
+}
+
+#[test]
+fn push_push_remote() {
+    let ctx = TestContext::setup_clone();
+    run(
+        ctx.dir.path(),
+        &["git", "config", "branch.main.pushRemote", "origin"],
+    );
+
+    snapshot!(ctx, "Pp");
+}
+
+#[test]
+fn push_upstream_prompt() {
+    let ctx = TestContext::setup_clone();
+    run(ctx.dir.path(), &["git", "branch", "--unset-upstream"]);
+    snapshot!(ctx, "Pu");
+}
+
+#[test]
+fn push_push_remote_prompt() {
     let ctx = TestContext::setup_clone();
     commit(ctx.dir.path(), "new-file", "");
     snapshot!(ctx, "Pp");
 }
 
 #[test]
+fn push_setup_upstream() {
+    let ctx = TestContext::setup_clone();
+    run(ctx.dir.path(), &["git", "checkout", "-b", "new-branch"]);
+    commit(ctx.dir.path(), "new-file", "");
+    snapshot!(ctx, "Pumain<enter>P");
+}
+
+#[test]
+fn push_setup_upstream_same_as_head() {
+    let ctx = TestContext::setup_clone();
+    run(ctx.dir.path(), &["git", "checkout", "-b", "new-branch"]);
+    commit(ctx.dir.path(), "new-file", "");
+    snapshot!(ctx, "Punew-branch<enter>");
+}
+
+#[test]
+fn push_setup_push_remote() {
+    let ctx = TestContext::setup_clone();
+    snapshot!(ctx, "Pporigin<enter>P");
+}
+
+#[test]
 fn force_push() {
     let ctx = TestContext::setup_clone();
     commit(ctx.dir.path(), "new-file", "");
-    snapshot!(ctx, "P-fp");
+    snapshot!(ctx, "P-fu");
 }
 
 #[test]
@@ -19,6 +83,14 @@ fn open_push_menu_after_dash_input() {
     let ctx = TestContext::setup_clone();
     commit(ctx.dir.path(), "new-file", "");
     snapshot!(ctx, "-P");
+}
+
+#[test]
+fn push_menu_no_branch() {
+    let ctx = TestContext::setup_clone();
+    run(ctx.dir.path(), &["git", "checkout", ""]);
+    // TODO `llbb<enter>q` is a hack to checkout a commit directly (detach HEAD)
+    snapshot!(ctx, "llbb<enter>qP");
 }
 
 #[test]

--- a/src/tests/remote.rs
+++ b/src/tests/remote.rs
@@ -1,0 +1,73 @@
+use git2::{Buf, Error, Repository};
+
+use crate::git::remote::*;
+use crate::tests::helpers::{run, RepoTestContext};
+
+fn get_head_name(repo: &Repository) -> String {
+    repo.head().unwrap().name().unwrap().into()
+}
+
+fn get_branch_remote(repo: &Repository) -> Result<Buf, Error> {
+    repo.branch_upstream_remote(&get_head_name(repo))
+}
+
+fn get_branch_remote_str(repo: &Repository) -> String {
+    get_branch_remote(repo).unwrap().as_str().unwrap().into()
+}
+
+#[test]
+fn set_push_remote_basic() {
+    let ctx = RepoTestContext::setup_clone();
+
+    let repo = ctx.local_repo;
+
+    let push_remote = get_push_remote(&repo).unwrap();
+    assert_eq!(push_remote, None);
+
+    let remote_name = get_branch_remote_str(&repo);
+    let remote = repo.find_remote(&remote_name).unwrap();
+    set_push_remote(&repo, Some(&remote)).unwrap();
+    let push_remote = get_push_remote(&repo).unwrap();
+    assert_eq!(push_remote, Some(remote_name));
+
+    set_push_remote(&repo, None).unwrap();
+    let push_remote = get_push_remote(&repo).unwrap();
+    assert_eq!(push_remote, None);
+}
+
+#[test]
+fn get_upstream_basic() {
+    let ctx = RepoTestContext::setup_clone();
+    let repo = ctx.local_repo;
+    let upstream = get_upstream(&repo).unwrap().unwrap();
+    assert_eq!(upstream.name().unwrap().unwrap(), "origin/main");
+
+    run(ctx.dir.path(), &["git", "branch", "--unset-upstream"]);
+    let upstream = get_upstream(&repo).unwrap();
+    assert!(upstream.is_none());
+}
+
+#[test]
+fn get_upstream_components_of_remote_branch() {
+    let ctx = RepoTestContext::setup_clone();
+    let repo = ctx.local_repo;
+
+    let (remote, branch) = get_upstream_components(&repo).unwrap().unwrap();
+    assert_eq!(remote, "origin");
+    assert_eq!(branch, "main");
+}
+
+#[test]
+fn get_upstream_components_of_feature_branch() {
+    let ctx = RepoTestContext::setup_clone();
+    let repo = ctx.local_repo;
+    run(ctx.dir.path(), &["git", "checkout", "-b", "feature-branch"]);
+    run(
+        ctx.dir.path(),
+        &["git", "branch", "--set-upstream-to", "main"],
+    );
+
+    let (remote, branch) = get_upstream_components(&repo).unwrap().unwrap();
+    assert_eq!(remote, ".");
+    assert_eq!(branch, "main");
+}

--- a/src/tests/snapshots/gitu__tests__pull__pull_menu_existing_push_remote_and_upstream.snap
+++ b/src/tests/snapshots/gitu__tests__pull__pull_menu_existing_push_remote_and_upstream.snap
@@ -1,14 +1,12 @@
 ---
-source: src/tests/push.rs
+source: src/tests/pull.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |
 ▌Your branch is up to date with 'origin/main'.                                  |
                                                                                 |
  Recent commits                                                                 |
- e7eb2bd main origin/main add new-file                                          |
- b66a0bf add initial-file                                                       |
-                                                                                |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -19,7 +17,9 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-$ git push --force-with-lease origin refs/heads/main:refs/heads/main            |
-To                                                                              |
-   b66a0bf..e7eb2bd  main -> main                                               |
-styles_hash: 346b2eb0e6fdb3f3
+Pull                    Arguments                                               |
+p from origin           -r Rebase local commits (--rebase)                      |
+u from origin/main                                                              |
+e from elsewhere                                                                |
+q/<esc> Quit/Close                                                              |
+styles_hash: bfa894f169425746

--- a/src/tests/snapshots/gitu__tests__pull__pull_menu_no_remote_or_upstream_set.snap
+++ b/src/tests/snapshots/gitu__tests__pull__pull_menu_no_remote_or_upstream_set.snap
@@ -1,13 +1,11 @@
 ---
-source: src/tests/push.rs
+source: src/tests/pull.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |
-▌Your branch is up to date with 'origin/main'.                                  |
                                                                                 |
  Recent commits                                                                 |
- e7eb2bd main origin/main add new-file                                          |
- b66a0bf add initial-file                                                       |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -19,7 +17,9 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-$ git push --force-with-lease origin refs/heads/main:refs/heads/main            |
-To                                                                              |
-   b66a0bf..e7eb2bd  main -> main                                               |
-styles_hash: 346b2eb0e6fdb3f3
+Pull                            Arguments                                       |
+p pushRemote, setting that      -r Rebase local commits (--rebase)              |
+u upstream, setting that                                                        |
+e from elsewhere                                                                |
+q/<esc> Quit/Close                                                              |
+styles_hash: 9294d1c15def01e9

--- a/src/tests/snapshots/gitu__tests__pull__pull_push_remote.snap
+++ b/src/tests/snapshots/gitu__tests__pull__pull_push_remote.snap
@@ -1,13 +1,12 @@
 ---
-source: src/tests/push.rs
+source: src/tests/pull.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |
 ▌Your branch is up to date with 'origin/main'.                                  |
                                                                                 |
  Recent commits                                                                 |
- e7eb2bd main origin/main add new-file                                          |
- b66a0bf add initial-file                                                       |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -19,7 +18,8 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-$ git push --force-with-lease origin refs/heads/main:refs/heads/main            |
-To                                                                              |
-   b66a0bf..e7eb2bd  main -> main                                               |
-styles_hash: 346b2eb0e6fdb3f3
+$ git pull origin refs/heads/main                                               |
+From                                                                            |
+ * branch            main       -> FETCH_HEAD                                   |
+Already up to date.                                                             |
+styles_hash: a7f12e4c3c38781e

--- a/src/tests/snapshots/gitu__tests__pull__pull_push_remote_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__pull__pull_push_remote_prompt.snap
@@ -1,13 +1,15 @@
 ---
-source: src/tests/push.rs
+source: src/tests/pull.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |
 ▌Your branch is up to date with 'origin/main'.                                  |
                                                                                 |
  Recent commits                                                                 |
- e7eb2bd main origin/main add new-file                                          |
- b66a0bf add initial-file                                                       |
+ b66a0bf main origin/main add initial-file                                      |
+                                                                                |
+                                                                                |
+                                                                                |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -19,7 +21,5 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-$ git push --force-with-lease origin refs/heads/main:refs/heads/main            |
-To                                                                              |
-   b66a0bf..e7eb2bd  main -> main                                               |
-styles_hash: 346b2eb0e6fdb3f3
+? Set pushRemote then pull: ›                                                   |
+styles_hash: e0d524e635f78ab7

--- a/src/tests/snapshots/gitu__tests__pull__pull_setup_push_remote.snap
+++ b/src/tests/snapshots/gitu__tests__pull__pull_setup_push_remote.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/pull.rs
+expression: ctx.redact_buffer()
+---
+▌On branch main                                                                 |
+▌Your branch is up to date with 'origin/main'.                                  |
+                                                                                |
+ Recent commits                                                                 |
+ b66a0bf main origin/main add initial-file                                      |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+────────────────────────────────────────────────────────────────────────────────|
+Pull                    Arguments                                               |
+p from origin           -r Rebase local commits (--rebase)                      |
+u from origin/main                                                              |
+e from elsewhere                                                                |
+q/<esc> Quit/Close                                                              |
+────────────────────────────────────────────────────────────────────────────────|
+$ git pull origin refs/heads/main                                               |
+From                                                                            |
+ * branch            main       -> FETCH_HEAD                                   |
+Already up to date.                                                             |
+styles_hash: 58b8068f5146eed2

--- a/src/tests/snapshots/gitu__tests__pull__pull_setup_upstream.snap
+++ b/src/tests/snapshots/gitu__tests__pull__pull_setup_upstream.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/pull.rs
+expression: ctx.redact_buffer()
+---
+▌On branch new-branch                                                           |
+▌Your branch is up to date with 'refs/heads/main'.                              |
+                                                                                |
+ Recent commits                                                                 |
+ b66a0bf main new-branch origin/main add initial-file                           |
+                                                                                |
+                                                                                |
+────────────────────────────────────────────────────────────────────────────────|
+Pull                            Arguments                                       |
+p pushRemote, setting that      -r Rebase local commits (--rebase)              |
+u from main                                                                     |
+e from elsewhere                                                                |
+q/<esc> Quit/Close                                                              |
+────────────────────────────────────────────────────────────────────────────────|
+$ git branch --set-upstream-to main                                             |
+branch 'new-branch' set up to track 'main'.                                     |
+$ git pull . refs/heads/main                                                    |
+From .                                                                          |
+ * branch            main       -> FETCH_HEAD                                   |
+Already up to date.                                                             |
+styles_hash: 9b65c93f218c4e5c

--- a/src/tests/snapshots/gitu__tests__pull__pull_setup_upstream_same_as_head.snap
+++ b/src/tests/snapshots/gitu__tests__pull__pull_setup_upstream_same_as_head.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/pull.rs
+expression: ctx.redact_buffer()
+---
+▌On branch new-branch                                                           |
+                                                                                |
+ Recent commits                                                                 |
+ b66a0bf main new-branch origin/main add initial-file                           |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+────────────────────────────────────────────────────────────────────────────────|
+Pull                            Arguments                                       |
+p pushRemote, setting that      -r Rebase local commits (--rebase)              |
+u upstream, setting that                                                        |
+e from elsewhere                                                                |
+q/<esc> Quit/Close                                                              |
+────────────────────────────────────────────────────────────────────────────────|
+$ git branch --set-upstream-to new-branch                                       |
+warning: not setting branch 'new-branch' as its own upstream                    |
+styles_hash: 6796d754f17d6809

--- a/src/tests/snapshots/gitu__tests__pull__pull_upstream.snap
+++ b/src/tests/snapshots/gitu__tests__pull__pull_upstream.snap
@@ -1,5 +1,5 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/pull.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |
@@ -12,14 +12,14 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
-                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
-$ git pull                                                                      |
+$ git pull origin refs/heads/main                                               |
 From                                                                            |
+ * branch            main       -> FETCH_HEAD                                   |
    b66a0bf..d07f2d3  main       -> origin/main                                  |
 Updating b66a0bf..d07f2d3                                                       |
 Fast-forward                                                                    |
  remote-file | 1 +                                                              |
  1 file changed, 1 insertion(+)                                                 |
  create mode 100644 remote-file                                                 |
-styles_hash: fe1a0f5d15268e04
+styles_hash: 5cab1b81bd346c16

--- a/src/tests/snapshots/gitu__tests__pull__pull_upstream_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__pull__pull_upstream_prompt.snap
@@ -1,13 +1,15 @@
 ---
-source: src/tests/push.rs
+source: src/tests/pull.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |
-▌Your branch is up to date with 'origin/main'.                                  |
                                                                                 |
  Recent commits                                                                 |
- e7eb2bd main origin/main add new-file                                          |
- b66a0bf add initial-file                                                       |
+ b66a0bf main origin/main add initial-file                                      |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -19,7 +21,5 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-$ git push --force-with-lease origin refs/heads/main:refs/heads/main            |
-To                                                                              |
-   b66a0bf..e7eb2bd  main -> main                                               |
-styles_hash: 346b2eb0e6fdb3f3
+? Set upstream then pull: ›                                                     |
+styles_hash: 6165a658809718f7

--- a/src/tests/snapshots/gitu__tests__push__push_menu_existing_push_remote_and_upstream.snap
+++ b/src/tests/snapshots/gitu__tests__push__push_menu_existing_push_remote_and_upstream.snap
@@ -6,9 +6,7 @@ expression: ctx.redact_buffer()
 ▌Your branch is up to date with 'origin/main'.                                  |
                                                                                 |
  Recent commits                                                                 |
- e7eb2bd main origin/main add new-file                                          |
- b66a0bf add initial-file                                                       |
-                                                                                |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -19,7 +17,9 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-$ git push --force-with-lease origin refs/heads/main:refs/heads/main            |
-To                                                                              |
-   b66a0bf..e7eb2bd  main -> main                                               |
-styles_hash: 346b2eb0e6fdb3f3
+Push                    Arguments                                               |
+p to origin             -n Dry run (--dry-run)                                  |
+u to origin/main        -F Force (--force)                                      |
+e to elsewhere          -f Force with lease (--force-with-lease)                |
+q/<esc> Quit/Close      -h Disable hooks (--no-verify)                          |
+styles_hash: b0f9b30d052cdc2e

--- a/src/tests/snapshots/gitu__tests__push__push_menu_no_branch.snap
+++ b/src/tests/snapshots/gitu__tests__push__push_menu_no_branch.snap
@@ -2,12 +2,10 @@
 source: src/tests/push.rs
 expression: ctx.redact_buffer()
 ---
-▌On branch main                                                                 |
-▌Your branch is up to date with 'origin/main'.                                  |
+▌On branch HEAD                                                                 |
                                                                                 |
  Recent commits                                                                 |
- e7eb2bd main origin/main add new-file                                          |
- b66a0bf add initial-file                                                       |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -19,7 +17,9 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-$ git push --force-with-lease origin refs/heads/main:refs/heads/main            |
-To                                                                              |
-   b66a0bf..e7eb2bd  main -> main                                               |
-styles_hash: 346b2eb0e6fdb3f3
+Push                               Arguments                                    |
+p error: Head is not a branch      -n Dry run (--dry-run)                       |
+u error: Head is not a branch      -F Force (--force)                           |
+e to elsewhere                     -f Force with lease (--force-with-lease)     |
+q/<esc> Quit/Close                 -h Disable hooks (--no-verify)               |
+styles_hash: 18ab2c30f676c031

--- a/src/tests/snapshots/gitu__tests__push__push_menu_no_remote_or_upstream_set.snap
+++ b/src/tests/snapshots/gitu__tests__push__push_menu_no_remote_or_upstream_set.snap
@@ -3,11 +3,9 @@ source: src/tests/push.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |
-▌Your branch is up to date with 'origin/main'.                                  |
                                                                                 |
  Recent commits                                                                 |
- e7eb2bd main origin/main add new-file                                          |
- b66a0bf add initial-file                                                       |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -19,7 +17,9 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-$ git push --force-with-lease origin refs/heads/main:refs/heads/main            |
-To                                                                              |
-   b66a0bf..e7eb2bd  main -> main                                               |
-styles_hash: 346b2eb0e6fdb3f3
+Push                            Arguments                                       |
+p pushRemote, setting that      -n Dry run (--dry-run)                          |
+u upstream, setting that        -F Force (--force)                              |
+e to elsewhere                  -f Force with lease (--force-with-lease)        |
+q/<esc> Quit/Close              -h Disable hooks (--no-verify)                  |
+styles_hash: 97c38ee7b4dd67be

--- a/src/tests/snapshots/gitu__tests__push__push_push_remote.snap
+++ b/src/tests/snapshots/gitu__tests__push__push_push_remote.snap
@@ -6,8 +6,9 @@ expression: ctx.redact_buffer()
 ▌Your branch is up to date with 'origin/main'.                                  |
                                                                                 |
  Recent commits                                                                 |
- e7eb2bd main origin/main add new-file                                          |
- b66a0bf add initial-file                                                       |
+ b66a0bf main origin/main add initial-file                                      |
+                                                                                |
+                                                                                |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -19,7 +20,6 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-$ git push --force-with-lease origin refs/heads/main:refs/heads/main            |
-To                                                                              |
-   b66a0bf..e7eb2bd  main -> main                                               |
-styles_hash: 346b2eb0e6fdb3f3
+$ git push origin refs/heads/main:refs/heads/main                               |
+Everything up-to-date                                                           |
+styles_hash: 8edd5c1754c00b3

--- a/src/tests/snapshots/gitu__tests__push__push_push_remote_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__push__push_push_remote_prompt.snap
@@ -3,11 +3,13 @@ source: src/tests/push.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |
-▌Your branch is up to date with 'origin/main'.                                  |
+▌Your branch is ahead of 'origin/main' by 1 commit.                             |
                                                                                 |
  Recent commits                                                                 |
- e7eb2bd main origin/main add new-file                                          |
- b66a0bf add initial-file                                                       |
+ e7eb2bd main add new-file                                                      |
+ b66a0bf origin/main add initial-file                                           |
+                                                                                |
+                                                                                |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -19,7 +21,5 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-$ git push --force-with-lease origin refs/heads/main:refs/heads/main            |
-To                                                                              |
-   b66a0bf..e7eb2bd  main -> main                                               |
-styles_hash: 346b2eb0e6fdb3f3
+? Set pushRemote then push: ›                                                   |
+styles_hash: 3978d3bb613672e

--- a/src/tests/snapshots/gitu__tests__push__push_setup_push_remote.snap
+++ b/src/tests/snapshots/gitu__tests__push__push_setup_push_remote.snap
@@ -6,12 +6,7 @@ expression: ctx.redact_buffer()
 ▌Your branch is up to date with 'origin/main'.                                  |
                                                                                 |
  Recent commits                                                                 |
- e7eb2bd main origin/main add new-file                                          |
- b66a0bf add initial-file                                                       |
-                                                                                |
-                                                                                |
-                                                                                |
-                                                                                |
+ b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -19,7 +14,12 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-$ git push --force-with-lease origin refs/heads/main:refs/heads/main            |
-To                                                                              |
-   b66a0bf..e7eb2bd  main -> main                                               |
-styles_hash: 346b2eb0e6fdb3f3
+Push                    Arguments                                               |
+p to origin             -n Dry run (--dry-run)                                  |
+u to origin/main        -F Force (--force)                                      |
+e to elsewhere          -f Force with lease (--force-with-lease)                |
+q/<esc> Quit/Close      -h Disable hooks (--no-verify)                          |
+────────────────────────────────────────────────────────────────────────────────|
+$ git push origin refs/heads/main:refs/heads/main                               |
+Everything up-to-date                                                           |
+styles_hash: b4add50771a9adbe

--- a/src/tests/snapshots/gitu__tests__push__push_setup_upstream.snap
+++ b/src/tests/snapshots/gitu__tests__push__push_setup_upstream.snap
@@ -2,24 +2,24 @@
 source: src/tests/push.rs
 expression: ctx.redact_buffer()
 ---
-▌On branch main                                                                 |
-▌Your branch is ahead of 'origin/main' by 1 commit.                             |
+▌On branch new-branch                                                           |
+▌Your branch is up to date with 'refs/heads/main'.                              |
                                                                                 |
  Recent commits                                                                 |
- e7eb2bd main add new-file                                                      |
+ e7eb2bd main new-branch add new-file                                           |
  b66a0bf origin/main add initial-file                                           |
-                                                                                |
-                                                                                |
-                                                                                |
-                                                                                |
-                                                                                |
-                                                                                |
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
 Push                            Arguments                                       |
 p pushRemote, setting that      -n Dry run (--dry-run)                          |
-u to origin/main                -F Force (--force)                              |
+u to main                       -F Force (--force)                              |
 e to elsewhere                  -f Force with lease (--force-with-lease)        |
 q/<esc> Quit/Close              -h Disable hooks (--no-verify)                  |
-styles_hash: 9707ae3534644d0c
+────────────────────────────────────────────────────────────────────────────────|
+$ git branch --set-upstream-to main                                             |
+branch 'new-branch' set up to track 'main'.                                     |
+$ git push . refs/heads/new-branch:refs/heads/main                              |
+To .                                                                            |
+   b66a0bf..e7eb2bd  new-branch -> main                                         |
+styles_hash: 26e2aff5c0eae868

--- a/src/tests/snapshots/gitu__tests__push__push_setup_upstream_same_as_head.snap
+++ b/src/tests/snapshots/gitu__tests__push__push_setup_upstream_same_as_head.snap
@@ -2,10 +2,10 @@
 source: src/tests/push.rs
 expression: ctx.redact_buffer()
 ---
-▌On branch main                                                                 |
-▌Your branch is up to date with 'origin/main'.                                  |
+▌On branch new-branch                                                           |
                                                                                 |
  Recent commits                                                                 |
+ e7eb2bd new-branch add new-file                                                |
  b66a0bf main origin/main add initial-file                                      |
                                                                                 |
                                                                                 |
@@ -13,13 +13,13 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
-                                                                                |
-                                                                                |
-                                                                                |
-                                                                                |
-                                                                                |
-                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
-$ git push origin                                                               |
-Everything up-to-date                                                           |
-styles_hash: baa329f6340fcc8b
+Push                            Arguments                                       |
+p pushRemote, setting that      -n Dry run (--dry-run)                          |
+u upstream, setting that        -F Force (--force)                              |
+e to elsewhere                  -f Force with lease (--force-with-lease)        |
+q/<esc> Quit/Close              -h Disable hooks (--no-verify)                  |
+────────────────────────────────────────────────────────────────────────────────|
+$ git branch --set-upstream-to new-branch                                       |
+warning: not setting branch 'new-branch' as its own upstream                    |
+styles_hash: b60340121bd76ccb

--- a/src/tests/snapshots/gitu__tests__push__push_upstream.snap
+++ b/src/tests/snapshots/gitu__tests__push__push_upstream.snap
@@ -19,7 +19,7 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-$ git push --force-with-lease origin refs/heads/main:refs/heads/main            |
+$ git push origin refs/heads/main:refs/heads/main                               |
 To                                                                              |
    b66a0bf..e7eb2bd  main -> main                                               |
-styles_hash: 346b2eb0e6fdb3f3
+styles_hash: 4281674f50fbf56f

--- a/src/tests/snapshots/gitu__tests__push__push_upstream_prompt.snap
+++ b/src/tests/snapshots/gitu__tests__push__push_upstream_prompt.snap
@@ -3,11 +3,13 @@ source: src/tests/push.rs
 expression: ctx.redact_buffer()
 ---
 ▌On branch main                                                                 |
-▌Your branch is up to date with 'origin/main'.                                  |
                                                                                 |
  Recent commits                                                                 |
- e7eb2bd main origin/main add new-file                                          |
- b66a0bf add initial-file                                                       |
+ b66a0bf main origin/main add initial-file                                      |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -19,7 +21,5 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-$ git push                                                                      |
-To                                                                              |
-   b66a0bf..e7eb2bd  main -> main                                               |
-styles_hash: 4b89bed7f095a906
+? Set upstream then push: ›                                                     |
+styles_hash: 6165a658809718f7

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -39,6 +39,11 @@ pub(crate) fn ui(frame: &mut Frame, state: &mut State) {
         None
     };
 
+    let maybe_prompt = state.prompt.data.as_ref().map(|prompt_data| SizedWidget {
+        height: 2,
+        widget: TextPrompt::new(prompt_data.prompt_text.clone()).with_block(popup_block()),
+    });
+
     let maybe_menu = state.pending_menu.as_ref().and_then(|menu| {
         if menu.is_hidden {
             None
@@ -48,13 +53,9 @@ pub(crate) fn ui(frame: &mut Frame, state: &mut State) {
                 &state.bindings,
                 menu,
                 state.screens.last().unwrap().get_selected_item(),
+                state,
             ))
         }
-    });
-
-    let maybe_prompt = state.prompt.data.as_ref().map(|prompt_data| SizedWidget {
-        height: 2,
-        widget: TextPrompt::new(prompt_data.prompt_text.clone()).with_block(popup_block()),
     });
 
     let layout = Layout::new(
@@ -70,14 +71,14 @@ pub(crate) fn ui(frame: &mut Frame, state: &mut State) {
 
     frame.render_widget(state.screens.last().unwrap(), layout[0]);
 
+    maybe_render(maybe_menu, frame, layout[2]);
+    maybe_render(maybe_log, frame, layout[3]);
+
     if let Some(prompt) = maybe_prompt {
         frame.render_stateful_widget(prompt, layout[1], &mut state.prompt.state);
         let (cx, cy) = state.prompt.state.cursor();
         frame.set_cursor(cx, cy);
     }
-
-    maybe_render(maybe_menu, frame, layout[2]);
-    maybe_render(maybe_log, frame, layout[3]);
 
     state.screens.last_mut().unwrap().size = layout[0];
 }

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -1,5 +1,7 @@
 use super::SizedWidget;
-use crate::{bindings::Bindings, config::Config, items::Item, menu::PendingMenu, ops::Op};
+use crate::{
+    bindings::Bindings, config::Config, items::Item, menu::PendingMenu, ops::Op, state::State,
+};
 use itertools::Itertools;
 use ratatui::{
     buffer::Buffer,
@@ -19,6 +21,7 @@ impl<'a> MenuWidget<'a> {
         bindings: &'a Bindings,
         pending: &'a PendingMenu,
         item: &'a Item,
+        state: &'a State,
     ) -> SizedWidget<Self> {
         let style = &config.style;
 
@@ -42,7 +45,10 @@ impl<'a> MenuWidget<'a> {
                     binds.into_iter().map(|bind| &bind.raw).join("/"),
                     &style.hotkey,
                 ),
-                Span::styled(format!(" {}", op.clone().implementation()), Style::new()),
+                Span::styled(
+                    format!(" {}", op.clone().implementation().display(state)),
+                    Style::new(),
+                ),
             ]));
         }
 
@@ -89,7 +95,7 @@ impl<'a> MenuWidget<'a> {
                 right_column.push(Line::from(vec![
                     Span::styled(&bind.raw, &style.hotkey),
                     Span::styled(
-                        format!(" {}", bind.op.clone().implementation()),
+                        format!(" {}", bind.op.clone().implementation().display(state)),
                         Style::new(),
                     ),
                 ]));


### PR DESCRIPTION
@rynoV I've been hacking around and testing things out. I opened up this new PR, but it continues on your work.
I'd appreciate any input on the code! :)

To summarize:
- Change bindings to `u` and `p`:
  `p` was previously the `push.default` (which often would be `upstream`).
  Now `u` is `upstream`, and `p` is `pushRemote`
- Fix when upstream was a local branch
- Make push-commands more explicit with refspecs (I copied Magit)
- Display `upstream` & `pushRemote` dynamically in the menus:
  `to origin/main` instead of `to upstream`

relates to: #58 