### PR TITLE
feat(config): Collapse screen headers via e.g. `general.collapsed_sec…

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,7 @@ pub(crate) struct Config {
 pub struct GeneralConfig {
     pub always_show_help: BoolConfigEntry,
     pub confirm_quit: BoolConfigEntry,
+    pub collapsed_sections: Vec<String>,
 }
 
 #[derive(Default, Debug, Deserialize)]

--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -5,6 +5,9 @@
 [general]
 always_show_help.enabled = false
 confirm_quit.enabled = false
+# Sets initially collapsed sections in the editor. e.g.:
+# collapsed_sections = ["untracked", "recent_commits", "branch_status"]
+collapsed_sections = []
 
 [style]
 # fg / bg can be either of:

--- a/src/screen/mod.rs
+++ b/src/screen/mod.rs
@@ -36,6 +36,14 @@ impl Screen {
         size: Size,
         refresh_items: Box<dyn Fn() -> Res<Vec<Item>>>,
     ) -> Res<Self> {
+        let collapsed = config
+            .general
+            .collapsed_sections
+            .clone()
+            .into_iter()
+            .map(Cow::Owned)
+            .collect();
+
         let mut screen = Self {
             cursor: 0,
             scroll: 0,
@@ -44,7 +52,7 @@ impl Screen {
             refresh_items,
             items: vec![],
             line_index: vec![],
-            collapsed: HashSet::new(),
+            collapsed,
         };
 
         screen.update()?;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -71,6 +71,20 @@ fn binary_file() {
 }
 
 #[test]
+fn collapsed_sections_config() {
+    let mut ctx = TestContext::setup_clone();
+    ctx.config().general.collapsed_sections = vec![
+        "untracked".into(),
+        "recent_commits".into(),
+        "branch_status".into(),
+        // TODO rebase / revert/ merge conlict?
+    ];
+    fs::write(ctx.dir.child("untracked_file.txt"), "").unwrap();
+
+    snapshot!(ctx, "");
+}
+
+#[test]
 fn log() {
     let ctx = TestContext::setup_clone();
     commit(ctx.dir.path(), "firstfile", "testing\ntesttest\n");

--- a/src/tests/snapshots/gitu__tests__collapsed_sections_config.snap
+++ b/src/tests/snapshots/gitu__tests__collapsed_sections_config.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/mod.rs
+expression: ctx.redact_buffer()
+---
+▌On branch main…                                                                |
+                                                                                |
+ Untracked files…                                                               |
+                                                                                |
+ Recent commits…                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: cbfd7594a526d60d


### PR DESCRIPTION
…tions = ["recent_commits"]`

Hide headers on the status screen e.g.
```
collapsed_sections = ["untracked", "recent_commits", "branch_status"]
```

@stackmystack I did some changes:
- added some consistency to the internal IDs
- changed the commit message (the changelog is auto-generated from commits)
- updated the `default_config.toml`


I'll go ahead and merge this!