### PR TITLE
feat: ctrl-c to quit the app

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -12,6 +12,7 @@ use arboard::Clipboard;
 use crossterm::event;
 use crossterm::event::Event;
 use crossterm::event::KeyCode;
+use crossterm::event::KeyEvent;
 use crossterm::event::KeyEventKind;
 use crossterm::event::KeyModifiers;
 use git2::Repository;
@@ -105,6 +106,7 @@ impl State {
                         screen.size = Size::new(w, h);
                     }
                 }
+                Event::Key(key) if self.is_system_quit(&key) => self.quit = true,
                 Event::Key(key) => {
                     if self.prompt.state.is_focused() {
                         self.prompt.state.handle_key_event(key)
@@ -134,6 +136,13 @@ impl State {
         }
 
         Ok(())
+    }
+
+    fn is_system_quit(&mut self, key: &KeyEvent) -> bool {
+        matches!(
+            (key.code, key.modifiers),
+            (KeyCode::Char('c'), KeyModifiers::CONTROL)
+        )
     }
 
     fn update_prompt(&mut self, term: &mut Term) -> Res<()> {


### PR DESCRIPTION
Resolves #258.

Firstly, thanks for this - I love magit and command line, so this feels like a perfect tool for me. As a thank you, I figured I will contribute a small ticket for you.

Now `ctrl-c` will exit the app bypassing any default or custom bindings. If you want to tweak the logic (for example exit only when the amount of screens is 1 i.e. root-level) - add more conditions to `is_system_quit` function.