### PR TITLE
Use `Stdio::inherit()` in `run_cmd_interactive` (likely fix for #215)

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -305,6 +305,8 @@ impl State {
         // Previously `Stdio::pipe()` was used here, likely causing
         // https://github.com/altsem/gitu/issues/215 and similar issues.
         cmd.stdin(Stdio::inherit());
+        // Redirect stderr so we can capture it via `Child::wait_with_output()`
+        cmd.stderr(Stdio::piped());
 
         // git will have staircased output in raw mode (issue #290)
         // disable raw mode temporarily for the git command

--- a/src/state.rs
+++ b/src/state.rs
@@ -302,11 +302,17 @@ impl State {
 
         cmd.current_dir(self.repo.workdir().expect("No workdir"));
 
-        cmd.stdin(Stdio::piped());
+        // Previously `Stdio::pipe()` was used here, likely causing
+        // https://github.com/altsem/gitu/issues/215 and similar issues.
+        cmd.stdin(Stdio::inherit());
 
         // git will have staircased output in raw mode (issue #290)
         // disable raw mode temporarily for the git command
         term.backend().disable_raw_mode()?;
+
+        // If we don't show the cursor prior spawning (thus restore the default
+        // state), the cursor may be missing in $EDITOR.
+        term.show_cursor()?;
 
         let child = cmd.spawn()?;
 


### PR DESCRIPTION
Likely fix for #215. `Command` is configured to `Stdio::pipe()` input to the spawned subprocess, likely causing the issues.

This commit also unhides the cursor before spawning the command, fixing hidden cursor issues when `git` spawns `EDITOR`.