### PR TITLE
Add support for `nvr` command with line number navigation

### DIFF
--- a/src/ops/show.rs
+++ b/src/ops/show.rs
@@ -79,6 +79,7 @@ fn parse_editor_command(editor: &str, file: &str, maybe_line: Option<u32>) -> Co
             || lower.ends_with("vim")
             || lower.ends_with("nvim")
             || lower.ends_with("nano")
+            || lower.ends_with("nvr")
         {
             cmd.args([&format!("+{}", line), file]);
         } else {


### PR DESCRIPTION
### About

This PR adds support for the `nvr` command, allowing users to jump directly to a specific line number using the `+[num]` option.

https://github.com/mhinz/neovim-remote