### PR TITLE
fix: respect pushDefault config option

### DIFF
--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -101,6 +101,17 @@ pub(crate) fn head_push_remote_cfg(repo: &Repository) -> Res<String> {
     } else {
         return Err("Head is not a branch".into());
     };
+
     let push_remote_cfg = format!("branch.{branch}.pushRemote");
-    Ok(push_remote_cfg)
+    let config = repo.config()?;
+    if config.get_string(&push_remote_cfg).is_ok() {
+        Ok(push_remote_cfg)
+    } else {
+        let push_default_cfg = "remote.pushDefault".to_string();
+        if config.get_string(&push_default_cfg).is_ok() {
+            Ok(push_default_cfg)
+        } else {
+            Err("Neither pushRemote nor push.default is configured".into())
+        }
+    }
 }


### PR DESCRIPTION
This fixes #322 , so that if no remote to push to is set, the default option set by
```
[remote]
	pushDefault = origin
```
Is used instead.