### PR TITLE
Fix a process bug when running show commands on Windows

### DIFF
--- a/src/ops/show.rs
+++ b/src/ops/show.rs
@@ -69,6 +69,15 @@ fn editor(file: &Path, maybe_line: Option<u32>) -> Option<Action> {
 
 fn parse_editor_command(editor: &str, file: &str, maybe_line: Option<u32>) -> Command {
     let args = &editor.split_whitespace().collect::<Vec<_>>();
+    #[cfg(windows)]
+    let mut cmd = {
+        let mut c = Command::new("cmd");
+        c.arg("/C");
+        c.arg(args[0]);
+        c
+    };
+
+    #[cfg(not(windows))]
     let mut cmd = Command::new(args[0]);
     cmd.args(&args[1..]);
 


### PR DESCRIPTION
With the released version, _all_ gitu commands for showing, editing etc. using the `EDITOR` env var and others will fail because we try to launch the subprocess command directly.

On Windows, this doesn't work; Commands need to be prepended with `cmd /C` to be executed in sub-shells.