### PR TITLE
show: Add `GITU_SHOW_EDITOR` env-var

### DIFF
--- a/src/ops/show.rs
+++ b/src/ops/show.rs
@@ -50,7 +50,7 @@ fn goto_show_screen(r: String) -> Option<Action> {
     }))
 }
 
-pub(crate) const EDITOR_VARS: [&str; 3] = ["VISUAL", "EDITOR", "GIT_EDITOR"];
+pub(crate) const EDITOR_VARS: [&str; 4] = ["GITU_SHOW_EDITOR", "VISUAL", "EDITOR", "GIT_EDITOR"];
 fn editor(file: &Path, maybe_line: Option<u32>) -> Option<Action> {
     let file = file.to_str().unwrap().to_string();
 


### PR DESCRIPTION
This allows users to set a custom editor used for 'show' (e.g. pressing RET on a file in the status buffer).

Please let me know if you would prefer a PR that adds this to the config file. 