### PR TITLE
feat: Switch terminal backend from Crossterm to Termwiz

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.18"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -317,7 +317,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -343,9 +343,9 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "compact_str"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6050c3a16ddab2e412160b31f2c871015704239bca62f72f6e5f0be631d3f644"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -496,6 +496,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,7 +580,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -674,9 +709,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -694,101 +729,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.85",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
-
-[[package]]
-name = "futures-task"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
-
-[[package]]
-name = "futures-util"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "pin-utils",
- "slab",
 ]
 
 [[package]]
@@ -851,7 +791,7 @@ checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -917,7 +857,6 @@ dependencies = [
  "tree-sitter-scala",
  "tree-sitter-toml",
  "tree-sitter-typescript",
- "tui-prompts",
  "unicode-segmentation",
  "unicode-width 0.2.0",
 ]
@@ -925,12 +864,6 @@ dependencies = [
 [[package]]
 name = "gitu-diff"
 version = "0.1.0"
-
-[[package]]
-name = "glob"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
@@ -1137,8 +1070,14 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.100",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1189,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.5"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "inotify"
@@ -1228,12 +1167,15 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.2"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b23a0c8dfe501baac4adf6ebbfa6eddf8f0c07f56b058cc1288017e32397846c"
+checksum = "0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d"
 dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1764,7 +1706,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1818,7 +1760,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1847,14 +1789,8 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.100",
 ]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -1907,19 +1843,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
-dependencies = [
- "toml_edit",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.88"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -1975,15 +1902,6 @@ dependencies = [
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
-]
-
-[[package]]
-name = "ratatui-macros"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fef540f80dbe8a0773266fa6077788ceb65ef624cdbf36e131aaf90b4a52df4"
-dependencies = [
- "ratatui",
 ]
 
 [[package]]
@@ -2062,51 +1980,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "relative-path"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
-
-[[package]]
-name = "rstest"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
-dependencies = [
- "futures",
- "futures-timer",
- "rstest_macros",
- "rustc_version",
-]
-
-[[package]]
-name = "rstest_macros"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
-dependencies = [
- "cfg-if",
- "glob",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "regex",
- "relative-path",
- "rustc_version",
- "syn 2.0.85",
- "unicode-ident",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver 1.0.23",
-]
-
-[[package]]
 name = "rustix"
 version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2129,14 +2002,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
@@ -2169,12 +2042,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
-
-[[package]]
 name = "semver-parser"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2200,7 +2067,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2299,15 +2166,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
-name = "slab"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2359,7 +2217,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.85",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2375,9 +2233,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.85"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2392,7 +2250,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2411,7 +2269,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix 1.0.5",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2461,7 +2319,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "phf",
- "semver 0.11.0",
+ "semver",
  "sha2",
  "signal-hook",
  "siphasher 0.3.11",
@@ -2497,7 +2355,7 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2777,18 +2635,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tui-prompts"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb6e0d8a972545cc209b933a1c06dab8932674b54ae19947834ec854fec2364f"
-dependencies = [
- "itertools 0.13.0",
- "ratatui",
- "ratatui-macros",
- "rstest",
-]
-
-[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2960,7 +2806,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.100",
  "wasm-bindgen-shared",
 ]
 
@@ -2982,7 +2828,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.100",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3096,7 +2942,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3341,7 +3187,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -3362,7 +3208,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -3385,5 +3231,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.100",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
 name = "arboard"
 version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +125,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +158,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -204,6 +240,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,7 +317,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -331,6 +373,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "criterion"
@@ -403,7 +454,7 @@ dependencies = [
  "crossterm_winapi",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.42",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -425,10 +476,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
+]
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
 
 [[package]]
 name = "displaydoc"
@@ -438,7 +545,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -487,6 +594,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad9cdb4b747e485a12abb0e6566612956c7a1bafa3bdb8d682c5b6d403589e48"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "figment"
 version = "0.10.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +632,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror",
+ "winapi",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +653,24 @@ dependencies = [
  "libredox",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "finl_unicode"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94c970b525906eb37d3940083aa65b95e481fc1857d467d13374e1d925cfc163"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -591,7 +752,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -631,6 +792,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "gethostname"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +809,29 @@ checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
 dependencies = [
  "libc",
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -657,7 +851,7 @@ checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -681,7 +875,6 @@ dependencies = [
  "chrono",
  "clap",
  "criterion",
- "crossterm",
  "etcetera",
  "figment",
  "git-version",
@@ -701,6 +894,7 @@ dependencies = [
  "simple-logging",
  "strip-ansi-escapes",
  "temp-dir",
+ "termwiz",
  "toml",
  "tree-sitter",
  "tree-sitter-bash",
@@ -789,6 +983,12 @@ name = "hermit-abi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"
@@ -937,7 +1137,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1033,7 +1233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b23a0c8dfe501baac4adf6ebbfa6eddf8f0c07f56b058cc1288017e32397846c"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1134,6 +1334,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,6 +1399,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "litemap"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,10 +1436,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix 0.29.0",
+ "winapi",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -1244,8 +1490,34 @@ dependencies = [
  "hermit-abi 0.3.9",
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.7.1",
+ "pin-utils",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -1284,6 +1556,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7393c226621f817964ffb3dc5704f9509e107a8b024b489cc2c1b217378785df"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1407,6 +1690,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1442,6 +1734,103 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pest"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d214365f632b123a47fd913301e14c946c61d1c183ee245fa76eb752e59a02dd"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb55586734301717aea2ac313f50b2eb8f60d2fc3dc01d190eefa2e625f60c4e"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75da2a70cf4d9cb76833c990ac9cd3923c9a8905a8929789ce347c84564d03d"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher 1.0.1",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1458,7 +1847,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1545,6 +1934,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
 name = "ratatui"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1561,6 +1971,7 @@ dependencies = [
  "paste",
  "serde",
  "strum",
+ "termwiz",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
@@ -1608,6 +2019,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.15",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -1671,7 +2093,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn",
+ "syn 2.0.85",
  "unicode-ident",
 ]
 
@@ -1681,7 +2103,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver",
+ "semver 1.0.23",
 ]
 
 [[package]]
@@ -1693,8 +2115,21 @@ dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.14",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+dependencies = [
+ "bitflags 2.6.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1726,9 +2161,27 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -1747,7 +2200,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1769,6 +2222,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1821,6 +2285,18 @@ dependencies = [
  "log",
  "thread-id",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
@@ -1883,7 +2359,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.85",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1905,7 +2392,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1913,6 +2400,85 @@ name = "temp-dir"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc1ee6eef34f12f765cb94725905c6312b6610ab2b0940889cfe58dae7bc3c72"
+
+[[package]]
+name = "tempfile"
+version = "3.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.2",
+ "once_cell",
+ "rustix 1.0.5",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666cd3a6681775d22b200409aad3b089c5b99fb11ecdd8a204d9d62f8148498f"
+dependencies = [
+ "dirs",
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a75313e21da5d4406ea31402035b3b97aa74c04356bdfafa5d1043ab4e551d1"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.6.0",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix 0.26.4",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "semver 0.11.0",
+ "sha2",
+ "signal-hook",
+ "siphasher 0.3.11",
+ "tempfile",
+ "terminfo",
+ "termios",
+ "thiserror",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
 
 [[package]]
 name = "thiserror"
@@ -1931,7 +2497,7 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2223,6 +2789,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "uncased"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2296,6 +2874,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+dependencies = [
+ "atomic",
+ "getrandom 0.3.2",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2317,6 +2905,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2331,6 +2928,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2354,7 +2960,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.85",
  "wasm-bindgen-shared",
 ]
 
@@ -2376,7 +2982,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.85",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2395,6 +3001,77 @@ checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.2",
+ "mac_address",
+ "sha2",
+ "thiserror",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "wezterm-dynamic",
 ]
 
 [[package]]
@@ -2419,7 +3096,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2601,6 +3278,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2619,7 +3305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d91ffca73ee7f68ce055750bf9f6eca0780b8c85eff9bc046a3b0da41755e12"
 dependencies = [
  "gethostname",
- "rustix",
+ "rustix 0.38.42",
  "x11rb-protocol",
 ]
 
@@ -2655,7 +3341,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.85",
  "synstructure",
 ]
 
@@ -2676,7 +3362,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.85",
  "synstructure",
 ]
 
@@ -2699,5 +3385,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.85",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ serde = { version = "1.0.219", features = ["derive"] }
 similar = { version = "2.7.0", features = ["unicode", "inline"] }
 simple-logging = "2.0.2"
 toml = "0.8.20"
-tui-prompts = "0.5.0"
 tree-sitter = "=0.20.10"
 tree-sitter-highlight = "=0.20.1"
 tree-sitter-rust = "=0.20.4"
@@ -64,5 +63,5 @@ tree-sitter-elixir = "=0.1.1"
 regex = "1.11.1"
 strip-ansi-escapes = "0.2.1"
 unicode-segmentation = "1.12.0"
-ratatui = { version = "0.29.0", features = ["termwiz", "serde"] }
 termwiz = "0.22.0"
+ratatui = { version = "0.29.0", features = ["termwiz", "serde", "underline-color"], default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ arboard = { version = "3.4.0", default-features = false, features = [
 ] }
 chrono = "0.4.40"
 clap = { version = "4.5.34", features = ["derive"] }
-crossterm = "0.28.1"
 etcetera = "0.10.0"
 figment = { version = "0.10.19", features = ["toml"] }
 git-version = "0.3.9"
@@ -36,7 +35,6 @@ itertools = "0.14.0"
 log = "0.4.27"
 nom = "7.1.3"
 notify = "7.0.0"
-ratatui = { version = "0.29.0", features = ["serde"] }
 serde = { version = "1.0.219", features = ["derive"] }
 similar = { version = "2.7.0", features = ["unicode", "inline"] }
 simple-logging = "2.0.2"
@@ -66,3 +64,5 @@ tree-sitter-elixir = "=0.1.1"
 regex = "1.11.1"
 strip-ansi-escapes = "0.2.1"
 unicode-segmentation = "1.12.0"
+ratatui = { version = "0.29.0", features = ["termwiz", "serde"] }
+termwiz = "0.22.0"

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1,11 +1,12 @@
 use std::collections::BTreeMap;
 
+use termwiz::input::{KeyCode, Modifiers};
+
 use crate::{
     key_parser,
     menu::{Menu, PendingMenu},
     ops::Op,
 };
-use crossterm::event::{KeyCode, KeyModifiers};
 
 pub(crate) struct Bindings {
     vec: Vec<Binding>,
@@ -32,7 +33,7 @@ impl Bindings {
     pub(crate) fn match_bindings<'a>(
         &'a self,
         pending: &'a Menu,
-        events: &'a [(KeyModifiers, KeyCode)],
+        events: &'a [(Modifiers, KeyCode)],
     ) -> impl Iterator<Item = &'a Binding> + 'a {
         self.vec
             .iter()
@@ -79,7 +80,7 @@ impl Bindings {
 pub(crate) struct Binding {
     pub menu: Menu,
     pub raw: String,
-    pub keys: Vec<(KeyModifiers, KeyCode)>,
+    pub keys: Vec<(Modifiers, KeyCode)>,
     pub op: Op,
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,7 @@ pub enum Error {
     OpenRepo(git2::Error),
     FindGitDir(io::Error),
     Term(io::Error),
+    Termwiz(ratatui::termwiz::Error),
     GitDirUtf8(string::FromUtf8Error),
     Config(figment::Error),
     FileWatcherGitignore(ignore::Error),
@@ -62,6 +63,7 @@ impl Display for Error {
             },
             Error::FindGitDir(e) => f.write_fmt(format_args!("Couldn't find git directory: {}", e)),
             Error::Term(e) => f.write_fmt(format_args!("Terminal error: {}", e)),
+            Error::Termwiz(e) => f.write_fmt(format_args!("Terminal error: {}", e)),
             Error::GitDirUtf8(_e) => f.write_str("Git directory not valid UTF-8"),
             Error::Config(e) => f.write_fmt(format_args!("Configuration error: {}", e)),
             Error::FileWatcherGitignore(e) => {

--- a/src/key_parser.rs
+++ b/src/key_parser.rs
@@ -71,15 +71,7 @@ fn parse_modifier(input: &str) -> IResult<&str, Modifiers> {
 
 fn parse_char_key(input: &str) -> IResult<&str, (Modifiers, KeyCode)> {
     none_of("<>")(input)?;
-    map(anychar, |c| {
-        let modifiers = if c.is_uppercase() {
-            Modifiers::SHIFT
-        } else {
-            Modifiers::NONE
-        };
-
-        (modifiers, KeyCode::Char(c))
-    })(input)
+    map(anychar, |c| (Modifiers::NONE, KeyCode::Char(c)))(input)
 }
 
 #[cfg(test)]
@@ -100,7 +92,7 @@ mod tests {
     fn upper_char() {
         assert_eq!(
             parse_keys("A"),
-            Ok(("", vec![(Modifiers::SHIFT, Char('A'))]))
+            Ok(("", vec![(Modifiers::NONE, Char('A'))]))
         );
     }
 
@@ -145,7 +137,7 @@ mod tests {
                 vec![
                     (Modifiers::NONE, Char('1')),
                     (Modifiers::ALT, End),
-                    (Modifiers::SHIFT, Char('A')),
+                    (Modifiers::NONE, Char('A')),
                 ]
             ))
         );

--- a/src/key_parser.rs
+++ b/src/key_parser.rs
@@ -1,4 +1,3 @@
-use crossterm::event::{KeyCode, KeyModifiers};
 use nom::{
     branch::alt,
     bytes::complete::tag,
@@ -8,72 +7,75 @@ use nom::{
     sequence::{delimited, preceded},
     IResult,
 };
+use termwiz::input::{KeyCode, Modifiers};
 
 // TODO Improve error messages
 
-pub(crate) fn parse_keys(input: &str) -> IResult<&str, Vec<(KeyModifiers, KeyCode)>> {
+pub(crate) fn parse_keys(input: &str) -> IResult<&str, Vec<(Modifiers, KeyCode)>> {
     all_consuming(many0(parse_key))(input)
 }
 
-fn parse_key(input: &str) -> IResult<&str, (KeyModifiers, KeyCode)> {
+fn parse_key(input: &str) -> IResult<&str, (Modifiers, KeyCode)> {
     alt((parse_quoted, parse_char_key))(input)
 }
 
-fn parse_quoted(input: &str) -> IResult<&str, (KeyModifiers, KeyCode)> {
+fn parse_quoted(input: &str) -> IResult<&str, (Modifiers, KeyCode)> {
     delimited(char('<'), parse_modifiers_and_key, char('>'))(input)
 }
 
-fn parse_modifiers_and_key(input: &str) -> IResult<&str, (KeyModifiers, KeyCode)> {
+fn parse_modifiers_and_key(input: &str) -> IResult<&str, (Modifiers, KeyCode)> {
     let (input, mods_vec) = separated_list0(tag("+"), parse_modifier)(input)?;
     let mods = mods_vec
         .into_iter()
-        .reduce(KeyModifiers::union)
-        .unwrap_or(KeyModifiers::NONE);
+        .reduce(Modifiers::union)
+        .unwrap_or(Modifiers::NONE);
 
     preceded(opt(tag("+")), alt((parse_special_key, parse_char_key)))(input)
         .map(|(rem, (m, key))| (rem, (m.union(mods), key)))
 }
 
-fn parse_special_key(input: &str) -> IResult<&str, (KeyModifiers, KeyCode)> {
+fn parse_special_key(input: &str) -> IResult<&str, (Modifiers, KeyCode)> {
     alt((
         value(KeyCode::Backspace, tag("backspace")),
         value(KeyCode::Enter, tag("enter")),
-        value(KeyCode::Left, tag("left")),
-        value(KeyCode::Right, tag("right")),
-        value(KeyCode::Up, tag("up")),
-        value(KeyCode::Down, tag("down")),
+        value(KeyCode::LeftArrow, tag("left")),
+        value(KeyCode::RightArrow, tag("right")),
+        value(KeyCode::UpArrow, tag("up")),
+        value(KeyCode::DownArrow, tag("down")),
         value(KeyCode::Home, tag("home")),
         value(KeyCode::End, tag("end")),
         value(KeyCode::PageUp, tag("pageup")),
         value(KeyCode::PageDown, tag("pagedown")),
         value(KeyCode::Tab, tag("tab")),
-        value(KeyCode::BackTab, tag("backtab")),
+        // FIXME Drop this and mention in changelog
+        // value(KeyCode::BackTab, tag("backtab")),
         value(KeyCode::Delete, tag("delete")),
         value(KeyCode::Insert, tag("insert")),
-        value(KeyCode::Esc, tag("esc")),
+        value(KeyCode::Escape, tag("esc")),
         value(KeyCode::CapsLock, tag("capslock")),
     ))(input)
-    .map(|(rem, key)| (rem, (KeyModifiers::NONE, key)))
+    .map(|(rem, key)| (rem, (Modifiers::NONE, key)))
 }
 
-fn parse_modifier(input: &str) -> IResult<&str, KeyModifiers> {
+fn parse_modifier(input: &str) -> IResult<&str, Modifiers> {
     alt((
-        value(KeyModifiers::SHIFT, tag("shift")),
-        value(KeyModifiers::CONTROL, tag("ctrl")),
-        value(KeyModifiers::ALT, tag("alt")),
-        value(KeyModifiers::SUPER, tag("super")),
-        value(KeyModifiers::HYPER, tag("hyper")),
-        value(KeyModifiers::META, tag("meta")),
+        value(Modifiers::SHIFT, tag("shift")),
+        value(Modifiers::CTRL, tag("ctrl")),
+        value(Modifiers::ALT, tag("alt")),
+        value(Modifiers::SUPER, tag("super")),
+        // FIXME Drop these and mention in changelog
+        // value(Modifiers::HYPER, tag("hyper")),
+        // value(Modifiers::META, tag("meta")),
     ))(input)
 }
 
-fn parse_char_key(input: &str) -> IResult<&str, (KeyModifiers, KeyCode)> {
+fn parse_char_key(input: &str) -> IResult<&str, (Modifiers, KeyCode)> {
     none_of("<>")(input)?;
     map(anychar, |c| {
         let modifiers = if c.is_uppercase() {
-            KeyModifiers::SHIFT
+            Modifiers::SHIFT
         } else {
-            KeyModifiers::NONE
+            Modifiers::NONE
         };
 
         (modifiers, KeyCode::Char(c))
@@ -83,13 +85,14 @@ fn parse_char_key(input: &str) -> IResult<&str, (KeyModifiers, KeyCode)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use termwiz::input::Modifiers;
     use KeyCode::*;
 
     #[test]
     fn single_char() {
         assert_eq!(
             parse_keys("a"),
-            Ok(("", vec![(KeyModifiers::NONE, Char('a'))]))
+            Ok(("", vec![(Modifiers::NONE, Char('a'))]))
         );
     }
 
@@ -97,7 +100,7 @@ mod tests {
     fn upper_char() {
         assert_eq!(
             parse_keys("A"),
-            Ok(("", vec![(KeyModifiers::SHIFT, Char('A'))]))
+            Ok(("", vec![(Modifiers::SHIFT, Char('A'))]))
         );
     }
 
@@ -105,7 +108,7 @@ mod tests {
     fn special_key() {
         assert_eq!(
             parse_keys("<backspace>"),
-            Ok(("", vec![(KeyModifiers::NONE, KeyCode::Backspace)]))
+            Ok(("", vec![(Modifiers::NONE, KeyCode::Backspace)]))
         );
     }
 
@@ -113,7 +116,7 @@ mod tests {
     fn modifier() {
         assert_eq!(
             parse_keys("<ctrl+j>"),
-            Ok(("", vec![(KeyModifiers::CONTROL, KeyCode::Char('j'))]))
+            Ok(("", vec![(Modifiers::CTRL, KeyCode::Char('j'))]))
         );
     }
 
@@ -124,9 +127,9 @@ mod tests {
             Ok((
                 "",
                 vec![(
-                    KeyModifiers::SHIFT
-                        .union(KeyModifiers::CONTROL)
-                        .union(KeyModifiers::ALT),
+                    Modifiers::SHIFT
+                        .union(Modifiers::CTRL)
+                        .union(Modifiers::ALT),
                     KeyCode::Char('k')
                 )]
             ))
@@ -140,9 +143,9 @@ mod tests {
             Ok((
                 "",
                 vec![
-                    (KeyModifiers::NONE, Char('1')),
-                    (KeyModifiers::ALT, End),
-                    (KeyModifiers::SHIFT, Char('A')),
+                    (Modifiers::NONE, Char('1')),
+                    (Modifiers::ALT, End),
+                    (Modifiers::SHIFT, Char('A')),
                 ]
             ))
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@ pub mod term;
 mod tests;
 mod ui;
 
-use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventState, KeyModifiers};
 use error::Error;
 use file_watcher::FileWatcher;
 use git2::Repository;
@@ -33,6 +32,7 @@ use std::{
     time::Duration,
 };
 use term::Term;
+use termwiz::input::{InputEvent, KeyCode, KeyEvent, Modifiers};
 
 pub const LOG_FILE_NAME: &str = "gitu.log";
 
@@ -77,7 +77,7 @@ pub type Res<T> = Result<T, Error>;
 
 #[derive(Debug)]
 pub enum GituEvent {
-    Term(Event),
+    Term(InputEvent),
     FileUpdate,
     Refresh,
 }
@@ -120,8 +120,11 @@ pub fn run(args: &cli::Args, term: &mut Term) -> Res<()> {
         .transpose()?;
 
     while !state.quit {
-        let mut events = if event::poll(Duration::from_millis(100)).map_err(Error::Term)? {
-            vec![GituEvent::Term(event::read().map_err(Error::Term)?)]
+        let mut events = if let Some(event) = term
+            .backend_mut()
+            .poll_input(Some(Duration::from_millis(100)))?
+        {
+            vec![GituEvent::Term(event)]
         } else {
             vec![]
         };
@@ -166,18 +169,16 @@ fn open_repo_from_env() -> Res<Repository> {
 }
 
 fn handle_initial_send_keys(
-    keys: &[(KeyModifiers, KeyCode)],
+    keys: &[(Modifiers, KeyCode)],
     state: &mut state::State,
     term: &mut ratatui::prelude::Terminal<term::TermBackend>,
 ) -> Res<()> {
     let initial_events = keys
         .iter()
         .map(|(mods, key)| {
-            GituEvent::Term(Event::Key(KeyEvent {
-                code: *key,
+            GituEvent::Term(InputEvent::Key(KeyEvent {
+                key: *key,
                 modifiers: *mods,
-                kind: event::KeyEventKind::Press,
-                state: KeyEventState::NONE,
             }))
         })
         .collect::<Vec<_>>();

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,19 +18,20 @@ pub fn main() -> Res<()> {
             .map_err(Error::OpenLogFile)?;
     }
 
-    setup_term_and_run(&args)?;
+    let mut terminal = Terminal::new(term::create_backend()?).map_err(Error::Term)?;
 
-    Ok(())
-}
+    if args.print {
+        return gitu::run(&args, &mut terminal);
+    }
 
-fn setup_term_and_run(args: &Args) -> Res<()> {
-    log::debug!("Initializing terminal backend");
-    let mut terminal = Terminal::new(term::backend()).map_err(Error::Term)?;
+    terminal.backend_mut().enter_alternate_screen()?;
+    terminal.backend_mut().enable_raw_mode()?;
 
     // Prevents cursor flash when opening gitu
     terminal.hide_cursor().map_err(Error::Term)?;
     terminal.clear().map_err(Error::Term)?;
 
-    log::debug!("Starting app");
-    gitu::run(args, &mut terminal)
+    gitu::run(&args, &mut terminal)?;
+
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@ use clap::Parser;
 use gitu::{cli::Args, error::Error, term, Res};
 use log::LevelFilter;
 use ratatui::Terminal;
-use std::{backtrace::Backtrace, panic};
 
 pub fn main() -> Res<()> {
     let args = Args::parse();
@@ -19,19 +18,7 @@ pub fn main() -> Res<()> {
             .map_err(Error::OpenLogFile)?;
     }
 
-    panic::set_hook(Box::new(|panic_info| {
-        term::cleanup_alternate_screen();
-        term::cleanup_raw_mode();
-
-        eprintln!("{}", panic_info);
-        eprintln!("trace: \n{}", Backtrace::force_capture());
-    }));
-
-    if args.print {
-        setup_term_and_run(&args)?;
-    } else {
-        term::alternate_screen(|| term::raw_mode(|| setup_term_and_run(&args)))?
-    }
+    setup_term_and_run(&args)?;
 
     Ok(())
 }

--- a/src/ops/checkout.rs
+++ b/src/ops/checkout.rs
@@ -1,7 +1,6 @@
 use super::{create_prompt_with_default, selected_rev, Action, OpTrait};
 use crate::{items::TargetData, menu::arg::Arg, prompt::PromptData, state::State, term::Term, Res};
 use std::{process::Command, rc::Rc};
-use tui_prompts::State as _;
 
 pub(crate) fn init_args() -> Vec<Arg> {
     vec![]
@@ -53,8 +52,8 @@ impl OpTrait for CheckoutNewBranch {
 }
 
 fn checkout_new_branch_prompt_update(state: &mut State, term: &mut Term) -> Res<()> {
-    if state.prompt.state.status().is_done() {
-        let name = state.prompt.state.value().to_string();
+    if state.prompt.state.status.is_done() {
+        let name = state.prompt.state.value.to_string();
         state.prompt.reset(term)?;
 
         let mut cmd = Command::new("git");

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use tui_prompts::State as _;
 
 use crate::{
     cmd_log::CmdLogEntry, items::TargetData, menu::Menu, prompt::PromptData, state::State,
@@ -190,8 +189,8 @@ impl Display for Menu {
 
 pub(crate) fn create_y_n_prompt(mut action: Action, prompt: &'static str) -> Action {
     let update_fn = Rc::new(move |state: &mut State, term: &mut Term| {
-        if state.prompt.state.status().is_pending() {
-            match state.prompt.state.value() {
+        if state.prompt.state.status.is_pending() {
+            match &*state.prompt.state.value {
                 "y" => {
                     Rc::get_mut(&mut action).unwrap()(state, term)?;
                     state.prompt.reset(term)?;
@@ -267,8 +266,8 @@ pub(crate) fn set_prompt(
     state.prompt.set(PromptData {
         prompt_text,
         update_fn: Rc::new(move |state, term| {
-            if state.prompt.state.status().is_done() {
-                let input = state.prompt.state.value().to_string();
+            if state.prompt.state.status.is_done() {
+                let input = state.prompt.state.value.to_string();
                 state.prompt.reset(term)?;
 
                 let default_value = default_fn(state);

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -1,8 +1,17 @@
 use super::Res;
 use crate::{error::Error, ops::Action};
-use ratatui::{backend::Backend, Terminal};
-use std::borrow::Cow;
-use tui_prompts::{State as _, TextState};
+use itertools::chain;
+use ratatui::{
+    backend::Backend,
+    buffer::Buffer,
+    layout::Rect,
+    style::Stylize,
+    text::{Line, Span},
+    widgets::{Block, Paragraph, StatefulWidget, Widget},
+    Terminal,
+};
+use std::{borrow::Cow, iter::once};
+use termwiz::input::{KeyCode, KeyEvent, Modifiers};
 
 pub(crate) struct PromptData {
     pub(crate) prompt_text: Cow<'static, str>,
@@ -32,5 +41,344 @@ impl Prompt {
         self.state = TextState::new();
         terminal.hide_cursor().map_err(Error::Term)?;
         Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+pub struct TextState<'a> {
+    pub status: Status,
+    pub focus: FocusState,
+    position: usize,
+    pub cursor: (u16, u16),
+    pub value: Cow<'a, str>,
+}
+
+impl TextState<'_> {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            status: Status::Pending,
+            focus: FocusState::Unfocused,
+            position: 0,
+            cursor: (0, 0),
+            value: Cow::Borrowed(""),
+        }
+    }
+
+    /// Sets the focus state of the prompt to [`Focus::Focused`].
+    pub fn focus(&mut self) {
+        self.focus = FocusState::Focused;
+    }
+
+    /// Whether the prompt is focused.
+    pub fn is_focused(&self) -> bool {
+        self.focus == FocusState::Focused
+    }
+
+    pub fn len(&self) -> usize {
+        self.value.chars().count()
+    }
+
+    pub fn handle_key_event(&mut self, key_event: &KeyEvent) {
+        match (key_event.key, key_event.modifiers) {
+            (KeyCode::Enter, _) => self.complete(),
+            (KeyCode::Escape, _) | (KeyCode::Char('c'), Modifiers::CTRL) => self.abort(),
+            (KeyCode::LeftArrow, _) | (KeyCode::Char('b'), Modifiers::CTRL) => self.move_left(),
+            (KeyCode::RightArrow, _) | (KeyCode::Char('f'), Modifiers::CTRL) => self.move_right(),
+            (KeyCode::Home, _) | (KeyCode::Char('a'), Modifiers::CTRL) => self.move_start(),
+            (KeyCode::End, _) | (KeyCode::Char('e'), Modifiers::CTRL) => self.move_end(),
+            (KeyCode::Backspace, _) | (KeyCode::Char('h'), Modifiers::CTRL) => {
+                self.backspace();
+            }
+            (KeyCode::Delete, _) | (KeyCode::Char('d'), Modifiers::CTRL) => self.delete(),
+            (KeyCode::Char('k'), Modifiers::CTRL) => self.kill(),
+            (KeyCode::Char('u'), Modifiers::CTRL) => self.truncate(),
+            (KeyCode::Char(c), Modifiers::NONE | Modifiers::SHIFT) => self.push(c),
+            _ => {}
+        }
+    }
+
+    pub fn complete(&mut self) {
+        self.status = Status::Done;
+    }
+
+    pub fn abort(&mut self) {
+        self.status = Status::Aborted;
+    }
+
+    pub fn delete(&mut self) {
+        let position = self.position;
+        if position == self.len() {
+            return;
+        }
+        self.value = chain!(
+            self.value.chars().take(position),
+            self.value.chars().skip(position + 1)
+        )
+        .collect();
+    }
+
+    pub fn backspace(&mut self) {
+        let position = self.position;
+        if position == 0 {
+            return;
+        }
+        self.value = chain!(
+            self.value.chars().take(position.saturating_sub(1)),
+            self.value.chars().skip(position)
+        )
+        .collect();
+        self.position = position.saturating_sub(1);
+    }
+
+    pub fn move_right(&mut self) {
+        if self.position == self.len() {
+            return;
+        }
+        self.position = self.position.saturating_add(1);
+    }
+
+    pub fn move_left(&mut self) {
+        self.position = self.position.saturating_sub(1);
+    }
+
+    pub fn move_end(&mut self) {
+        self.position = self.len();
+    }
+
+    pub fn move_start(&mut self) {
+        self.position = 0;
+    }
+
+    pub fn kill(&mut self) {
+        let position = self.position;
+        self.value.to_string().truncate(position);
+    }
+
+    pub fn truncate(&mut self) {
+        self.value.to_mut().clear();
+        self.position = 0;
+    }
+
+    pub fn push(&mut self, c: char) {
+        if self.position == self.len() {
+            self.value.to_mut().push(c);
+        } else {
+            // We cannot use String::insert() as it operates on bytes, which can lead to incorrect modifications with
+            // multibyte characters. Instead, we handle text manipulation at the character level using Rust's char type
+            // for Unicode correctness. Check docs of String::insert() and String::chars() for futher info.
+            self.value = chain![
+                self.value.chars().take(self.position),
+                once(c),
+                self.value.chars().skip(self.position)
+            ]
+            .collect();
+        }
+        self.position = self.position.saturating_add(1);
+    }
+}
+
+#[derive(Debug, Clone, Default, Copy, PartialEq, Eq, Hash)]
+pub enum FocusState {
+    #[default]
+    Unfocused,
+    Focused,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Status {
+    #[default]
+    Pending,
+    Aborted,
+    Done,
+}
+
+impl Status {
+    #[must_use]
+    pub const fn is_pending(&self) -> bool {
+        matches!(self, Self::Pending)
+    }
+
+    #[must_use]
+    pub const fn is_done(&self) -> bool {
+        matches!(self, Self::Done)
+    }
+
+    #[must_use]
+    pub fn symbol(&self) -> Span<'static> {
+        match self {
+            Self::Pending => Symbols::default().pending,
+            Self::Aborted => Symbols::default().aborted,
+            Self::Done => Symbols::default().done,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Symbols {
+    pub pending: Span<'static>,
+    pub aborted: Span<'static>,
+    pub done: Span<'static>,
+}
+
+impl Default for Symbols {
+    fn default() -> Self {
+        Self {
+            pending: "?".cyan(),
+            aborted: "✘".red(),
+            done: "✔".green(),
+        }
+    }
+}
+
+/// A prompt widget that displays a message and a text input.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct TextPrompt<'a> {
+    /// The message to display to the user before the input.
+    message: Cow<'a, str>,
+    /// The block to wrap the prompt in.
+    block: Option<Block<'a>>,
+}
+
+impl<'a> TextPrompt<'a> {
+    #[must_use]
+    pub const fn new(message: Cow<'a, str>) -> Self {
+        Self {
+            message,
+            block: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_block(mut self, block: Block<'a>) -> Self {
+        self.block = Some(block);
+        self
+    }
+}
+
+// impl Prompt for TextPrompt<'_> {
+//     /// Draws the prompt widget.
+//     ///
+//     /// This is in addition to the `Widget` trait implementation as we need the `Frame` to set the
+//     /// cursor position.
+//     fn draw(self, frame: &mut Frame, area: Rect, state: &mut Self::State) {
+//         frame.render_stateful_widget(self, area, state);
+//         if state.is_focused() {
+//             frame.set_cursor_position(state.cursor());
+//         }
+//     }
+// }
+
+impl<'a> StatefulWidget for TextPrompt<'a> {
+    type State = TextState<'a>;
+
+    fn render(mut self, mut area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        self.render_block(&mut area, buf);
+
+        let width = area.width as usize;
+        let height = area.height as usize;
+        let value = state.value.clone();
+        let value_length = value.chars().count();
+
+        let line = Line::from(vec![
+            state.status.symbol(),
+            " ".into(),
+            self.message.bold(),
+            " › ".cyan().dim(),
+            Span::raw(value),
+        ]);
+        let prompt_length = line.width() - value_length;
+        let lines = wrap(line, width).take(height).collect::<Vec<_>>();
+
+        // constrain the position to the area
+        let position = (state.position + prompt_length).min(area.area() as usize - 1);
+        let row = position / width;
+        let column = position % width;
+        state.cursor = (area.x + column as u16, area.y + row as u16);
+        Paragraph::new(lines).render(area, buf);
+    }
+}
+
+/// wraps a line into multiple lines of the given width.
+///
+/// This is a character based wrap, not a word based wrap.
+///
+/// TODO: move this into the `Line` type.
+fn wrap(line: Line, width: usize) -> impl Iterator<Item = Line> {
+    let mut line = line;
+    std::iter::from_fn(move || {
+        if line.width() > width {
+            let (first, second) = line_split_at(line.clone(), width);
+            line = second;
+            Some(first)
+        } else if line.width() > 0 {
+            let first = line.clone();
+            line = Line::default();
+            Some(first)
+        } else {
+            None
+        }
+    })
+}
+
+/// splits a line into two lines at the given position.
+///
+/// TODO: move this into the `Line` type.
+/// TODO: fix this so that it operates on multi-width characters.
+fn line_split_at(line: Line, mid: usize) -> (Line, Line) {
+    let mut first = Line::default();
+    let mut second = Line::default();
+    first.alignment = line.alignment;
+    second.alignment = line.alignment;
+    for span in line.spans {
+        let first_width = first.width();
+        let span_width = span.width();
+        if first_width + span_width <= mid {
+            first.spans.push(span);
+        } else if first_width < mid && first_width + span_width > mid {
+            let span_mid = mid - first_width;
+            let (span_first, span_second) = span_split_at(span, span_mid);
+            first.spans.push(span_first);
+            second.spans.push(span_second);
+        } else {
+            second.spans.push(span);
+        }
+    }
+    (first, second)
+}
+
+/// splits a span into two spans at the given position.
+///
+/// TODO: move this into the `Span` type.
+/// TODO: fix this so that it operates on multi-width characters.
+fn span_split_at(span: Span, mid: usize) -> (Span, Span) {
+    let (first, second) = span.content.split_at(mid);
+    let first = Span {
+        content: Cow::Owned(first.into()),
+        style: span.style,
+    };
+    let second = Span {
+        content: Cow::Owned(second.into()),
+        style: span.style,
+    };
+    (first, second)
+}
+
+impl TextPrompt<'_> {
+    fn render_block(&mut self, area: &mut Rect, buf: &mut Buffer) {
+        if let Some(block) = self.block.take() {
+            let inner = block.inner(*area);
+            block.render(*area, buf);
+            *area = inner;
+        };
+    }
+}
+
+impl<T> From<T> for TextPrompt<'static>
+where
+    T: Into<Cow<'static, str>>,
+{
+    fn from(message: T) -> Self {
+        Self::new(message.into())
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -15,8 +15,6 @@ use termwiz::input::InputEvent;
 use termwiz::input::KeyCode;
 use termwiz::input::KeyEvent;
 use termwiz::input::Modifiers;
-use tui_prompts::State as _;
-use tui_prompts::Status;
 
 use crate::bindings::Bindings;
 use crate::cli;
@@ -28,6 +26,7 @@ use crate::menu::Menu;
 use crate::menu::PendingMenu;
 use crate::ops::Op;
 use crate::prompt;
+use crate::prompt::Status;
 use crate::screen;
 use crate::screen::Screen;
 use crate::term::Term;
@@ -111,8 +110,7 @@ impl State {
                 }
                 GituEvent::Term(InputEvent::Key(key)) => {
                     if self.prompt.state.is_focused() {
-                        todo!();
-                        // FIXME self.prompt.state.handle_key_event(key)
+                        self.prompt.state.handle_key_event(key);
                     } else {
                         if self.pending_cmd.is_none() {
                             self.current_cmd_log.clear();
@@ -146,7 +144,7 @@ impl State {
     }
 
     fn update_prompt(&mut self, term: &mut Term) -> Res<()> {
-        if self.prompt.state.status() == Status::Aborted {
+        if self.prompt.state.status == Status::Aborted {
             self.unhide_menu();
             self.prompt.reset(term)?;
         } else if let Some(mut prompt_data) = self.prompt.data.take() {

--- a/src/state.rs
+++ b/src/state.rs
@@ -9,13 +9,12 @@ use std::sync::Arc;
 use std::sync::RwLock;
 
 use arboard::Clipboard;
-use crossterm::event;
-use crossterm::event::Event;
-use crossterm::event::KeyCode;
-use crossterm::event::KeyEventKind;
-use crossterm::event::KeyModifiers;
 use git2::Repository;
 use ratatui::layout::Size;
+use termwiz::input::InputEvent;
+use termwiz::input::KeyCode;
+use termwiz::input::KeyEvent;
+use termwiz::input::Modifiers;
 use tui_prompts::State as _;
 use tui_prompts::Status;
 
@@ -41,7 +40,7 @@ pub(crate) struct State {
     pub repo: Rc<Repository>,
     pub config: Rc<Config>,
     pub bindings: Bindings,
-    pending_keys: Vec<(KeyModifiers, KeyCode)>,
+    pending_keys: Vec<(Modifiers, KeyCode)>,
     pub quit: bool,
     pub screens: Vec<Screen>,
     pub pending_menu: Option<PendingMenu>,
@@ -103,21 +102,23 @@ impl State {
         for event in events {
             log::debug!("{:?}", event);
 
-            match *event {
-                GituEvent::Term(Event::Resize(w, h)) => {
+            match event {
+                GituEvent::Term(InputEvent::Resized { cols, rows }) => {
                     for screen in self.screens.iter_mut() {
-                        screen.size = Size::new(w, h);
+                        screen.size =
+                            Size::new({ *cols }.try_into().unwrap(), { *rows }.try_into().unwrap());
                     }
                 }
-                GituEvent::Term(Event::Key(key)) => {
+                GituEvent::Term(InputEvent::Key(key)) => {
                     if self.prompt.state.is_focused() {
-                        self.prompt.state.handle_key_event(key)
-                    } else if key.kind == KeyEventKind::Press {
+                        todo!();
+                        // FIXME self.prompt.state.handle_key_event(key)
+                    } else {
                         if self.pending_cmd.is_none() {
                             self.current_cmd_log.clear();
                         }
 
-                        self.handle_key_input(term, key)?;
+                        self.handle_key_input(term, key.clone())?;
                     }
                 }
                 GituEvent::FileUpdate => {
@@ -166,14 +167,14 @@ impl State {
         Ok(())
     }
 
-    fn handle_key_input(&mut self, term: &mut Term, key: event::KeyEvent) -> Res<()> {
+    fn handle_key_input(&mut self, term: &mut Term, key: KeyEvent) -> Res<()> {
         let menu = match &self.pending_menu {
             None => Menu::Root,
             Some(menu) if menu.menu == Menu::Help => Menu::Root,
             Some(menu) => menu.menu,
         };
 
-        self.pending_keys.push((key.modifiers, key.code));
+        self.pending_keys.push((key.modifiers, key.key));
         let matching_bindings = self
             .bindings
             .match_bindings(&menu, &self.pending_keys)
@@ -326,7 +327,7 @@ impl State {
 
         // git will have staircased output in raw mode (issue #290)
         // disable raw mode temporarily for the git command
-        term.backend().disable_raw_mode()?;
+        term.backend_mut().disable_raw_mode()?;
 
         // If we don't show the cursor prior spawning (thus restore the default
         // state), the cursor may be missing in $EDITOR.
@@ -356,7 +357,7 @@ impl State {
         self.current_cmd_log.push_cmd_with_output(&cmd, out_utf8);
 
         // restore the raw mode
-        term.backend().enable_raw_mode()?;
+        term.backend_mut().enable_raw_mode()?;
 
         // Prevents cursor flash when exiting editor
         term.hide_cursor().map_err(Error::Term)?;

--- a/src/term.rs
+++ b/src/term.rs
@@ -7,13 +7,24 @@ use ratatui::{
 };
 use std::io::{self};
 use std::time::Duration;
-use termwiz::{input::InputEvent, terminal::Terminal as _};
+use termwiz::{
+    caps::Capabilities,
+    input::InputEvent,
+    terminal::{buffered::BufferedTerminal, SystemTerminal, Terminal as _},
+};
 
 pub type Term = Terminal<TermBackend>;
 
-pub fn backend() -> TermBackend {
-    // TODO Remove unwrap
-    TermBackend::Termwiz(TermwizBackend::new().unwrap())
+pub fn create_backend() -> Res<TermBackend> {
+    let buffered_terminal = BufferedTerminal::new(
+        SystemTerminal::new(Capabilities::new_from_env().map_err(Error::Termwiz)?)
+            .map_err(Error::Termwiz)?,
+    )
+    .map_err(Error::Termwiz)?;
+
+    Ok(TermBackend::Termwiz(
+        TermwizBackend::with_buffered_terminal(buffered_terminal),
+    ))
 }
 
 pub enum TermBackend {

--- a/src/term.rs
+++ b/src/term.rs
@@ -1,59 +1,15 @@
 use crate::{error::Error, Res};
-use crossterm::{
-    terminal::{
-        disable_raw_mode, enable_raw_mode, is_raw_mode_enabled, EnterAlternateScreen,
-        LeaveAlternateScreen,
-    },
-    ExecutableCommand,
-};
 use ratatui::{
-    backend::{Backend, CrosstermBackend, TestBackend},
+    backend::{Backend, TestBackend},
     layout::Size,
-    prelude::{backend::WindowSize, buffer::Cell, Position},
+    prelude::{backend::WindowSize, buffer::Cell, Position, TermwizBackend},
     Terminal,
 };
-use std::fmt::Display;
-use std::io::{self, stderr, Stderr};
+use std::io::{self};
+use std::{fmt::Display, time::Duration};
+use termwiz::{input::InputEvent, terminal::Terminal as _};
 
 pub type Term = Terminal<TermBackend>;
-
-// TODO It would be more logical if the following top-level functions also were in 'TermBackend'.
-//      However left here for now.
-
-pub fn alternate_screen<T, F: Fn() -> Res<T>>(fun: F) -> Res<T> {
-    stderr()
-        .execute(EnterAlternateScreen)
-        .map_err(Error::Term)?;
-    let result = fun();
-    stderr()
-        .execute(LeaveAlternateScreen)
-        .map_err(Error::Term)?;
-    result
-}
-
-pub fn raw_mode<T, F: Fn() -> Res<T>>(fun: F) -> Res<T> {
-    let was_raw_mode_enabled = is_raw_mode_enabled().map_err(Error::Term)?;
-
-    if !was_raw_mode_enabled {
-        enable_raw_mode().map_err(Error::Term)?;
-    }
-
-    let result = fun();
-
-    if !was_raw_mode_enabled {
-        disable_raw_mode().map_err(Error::Term)?;
-    }
-
-    result
-}
-
-pub fn cleanup_alternate_screen() {
-    print_err(stderr().execute(LeaveAlternateScreen));
-}
-
-pub fn cleanup_raw_mode() {
-    print_err(disable_raw_mode());
-}
 
 fn print_err<T, E: Display>(result: Result<T, E>) {
     match result {
@@ -63,11 +19,12 @@ fn print_err<T, E: Display>(result: Result<T, E>) {
 }
 
 pub fn backend() -> TermBackend {
-    TermBackend::Crossterm(CrosstermBackend::new(stderr()))
+    // TODO Remove unwrap
+    TermBackend::Termwiz(TermwizBackend::new().unwrap())
 }
 
 pub enum TermBackend {
-    Crossterm(CrosstermBackend<Stderr>),
+    Termwiz(TermwizBackend),
     #[allow(dead_code)]
     Test(TestBackend),
 }
@@ -78,63 +35,63 @@ impl Backend for TermBackend {
         I: Iterator<Item = (u16, u16, &'a Cell)>,
     {
         match self {
-            TermBackend::Crossterm(t) => t.draw(content),
+            TermBackend::Termwiz(t) => t.draw(content),
             TermBackend::Test(t) => t.draw(content),
         }
     }
 
     fn hide_cursor(&mut self) -> io::Result<()> {
         match self {
-            TermBackend::Crossterm(t) => t.hide_cursor(),
+            TermBackend::Termwiz(t) => t.hide_cursor(),
             TermBackend::Test(t) => t.hide_cursor(),
         }
     }
 
     fn show_cursor(&mut self) -> io::Result<()> {
         match self {
-            TermBackend::Crossterm(t) => t.show_cursor(),
+            TermBackend::Termwiz(t) => t.show_cursor(),
             TermBackend::Test(t) => t.show_cursor(),
         }
     }
 
     fn get_cursor_position(&mut self) -> io::Result<Position> {
         match self {
-            TermBackend::Crossterm(t) => t.get_cursor_position(),
+            TermBackend::Termwiz(t) => t.get_cursor_position(),
             TermBackend::Test(t) => t.get_cursor_position(),
         }
     }
 
     fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> io::Result<()> {
         match self {
-            TermBackend::Crossterm(t) => t.set_cursor_position(position),
+            TermBackend::Termwiz(t) => t.set_cursor_position(position),
             TermBackend::Test(t) => t.set_cursor_position(position),
         }
     }
 
     fn clear(&mut self) -> io::Result<()> {
         match self {
-            TermBackend::Crossterm(t) => t.clear(),
+            TermBackend::Termwiz(t) => t.clear(),
             TermBackend::Test(t) => t.clear(),
         }
     }
 
     fn size(&self) -> io::Result<Size> {
         match self {
-            TermBackend::Crossterm(t) => t.size(),
+            TermBackend::Termwiz(t) => t.size(),
             TermBackend::Test(t) => t.size(),
         }
     }
 
     fn window_size(&mut self) -> io::Result<WindowSize> {
         match self {
-            TermBackend::Crossterm(t) => t.window_size(),
+            TermBackend::Termwiz(t) => t.window_size(),
             TermBackend::Test(t) => t.window_size(),
         }
     }
 
     fn flush(&mut self) -> io::Result<()> {
         match self {
-            TermBackend::Crossterm(t) => t.flush(),
+            TermBackend::Termwiz(t) => t.flush(),
             TermBackend::Test(t) => t.flush(),
         }
     }
@@ -143,25 +100,45 @@ impl Backend for TermBackend {
 impl TermBackend {
     pub fn enter_alternate_screen(&mut self) -> Res<()> {
         match self {
-            TermBackend::Crossterm(c) => c
-                .execute(EnterAlternateScreen)
-                .map_err(Error::Term)
-                .map(|_| ()),
+            TermBackend::Termwiz(c) => c
+                .buffered_terminal_mut()
+                .terminal()
+                .enter_alternate_screen()
+                .map_err(Error::Termwiz),
             TermBackend::Test(_) => Ok(()),
         }
     }
 
-    pub fn enable_raw_mode(&self) -> Res<()> {
+    pub fn enable_raw_mode(&mut self) -> Res<()> {
         match self {
-            TermBackend::Crossterm(_) => enable_raw_mode().map_err(Error::Term),
+            TermBackend::Termwiz(t) => t
+                .buffered_terminal_mut()
+                .terminal()
+                .set_raw_mode()
+                .map_err(Error::Termwiz),
             TermBackend::Test(_) => Ok(()),
         }
     }
 
-    pub fn disable_raw_mode(&self) -> Res<()> {
+    pub fn disable_raw_mode(&mut self) -> Res<()> {
         match self {
-            TermBackend::Crossterm(_) => disable_raw_mode().map_err(Error::Term),
+            TermBackend::Termwiz(t) => t
+                .buffered_terminal_mut()
+                .terminal()
+                .set_cooked_mode()
+                .map_err(Error::Termwiz),
             TermBackend::Test(_) => Ok(()),
+        }
+    }
+
+    pub fn poll_input(&mut self, wait: Option<Duration>) -> Res<Option<InputEvent>> {
+        match self {
+            TermBackend::Termwiz(t) => t
+                .buffered_terminal_mut()
+                .terminal()
+                .poll_input(wait)
+                .map_err(Error::Termwiz),
+            TermBackend::Test(test_backend) => todo!(),
         }
     }
 }

--- a/src/term.rs
+++ b/src/term.rs
@@ -6,17 +6,10 @@ use ratatui::{
     Terminal,
 };
 use std::io::{self};
-use std::{fmt::Display, time::Duration};
+use std::time::Duration;
 use termwiz::{input::InputEvent, terminal::Terminal as _};
 
 pub type Term = Terminal<TermBackend>;
-
-fn print_err<T, E: Display>(result: Result<T, E>) {
-    match result {
-        Ok(_) => (),
-        Err(error) => eprintln!("Error: {}", error),
-    };
-}
 
 pub fn backend() -> TermBackend {
     // TODO Remove unwrap
@@ -138,7 +131,7 @@ impl TermBackend {
                 .terminal()
                 .poll_input(wait)
                 .map_err(Error::Termwiz),
-            TermBackend::Test(test_backend) => todo!(),
+            TermBackend::Test(_test_backend) => unimplemented!(),
         }
     }
 }

--- a/src/tests/helpers/ui.rs
+++ b/src/tests/helpers/ui.rs
@@ -7,11 +7,11 @@ use crate::{
     tests::helpers::RepoTestContext,
     GituEvent,
 };
-use crossterm::event::{Event, KeyEvent};
 use git2::Repository;
 use ratatui::{backend::TestBackend, layout::Size, Terminal};
 use std::{path::PathBuf, rc::Rc};
 use temp_dir::TempDir;
+use termwiz::input::{InputEvent, KeyEvent};
 
 use self::buffer::TestBuffer;
 
@@ -111,6 +111,6 @@ pub fn keys(input: &str) -> Vec<GituEvent> {
     };
 
     keys.into_iter()
-        .map(|(mods, key)| GituEvent::Term(Event::Key(KeyEvent::new(key, mods))))
+        .map(|(mods, key)| GituEvent::Term(InputEvent::Key(KeyEvent::new(key, mods))))
         .collect()
 }

--- a/src/tests/helpers/ui.rs
+++ b/src/tests/helpers/ui.rs
@@ -111,6 +111,6 @@ pub fn keys(input: &str) -> Vec<GituEvent> {
     };
 
     keys.into_iter()
-        .map(|(mods, key)| GituEvent::Term(InputEvent::Key(KeyEvent::new(key, mods))))
+        .map(|(modifiers, key)| GituEvent::Term(InputEvent::Key(KeyEvent { key, modifiers })))
         .collect()
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,10 +1,9 @@
+use crate::prompt::TextPrompt;
 use crate::state::State;
 use ratatui::prelude::*;
 use ratatui::style::Stylize;
 use ratatui::widgets::*;
 use ratatui::Frame;
-use tui_prompts::State as _;
-use tui_prompts::TextPrompt;
 
 mod menu;
 
@@ -76,7 +75,7 @@ pub(crate) fn ui(frame: &mut Frame, state: &mut State) {
 
     if let Some(prompt) = maybe_prompt {
         frame.render_stateful_widget(prompt, layout[1], &mut state.prompt.state);
-        let (cx, cy) = state.prompt.state.cursor();
+        let (cx, cy) = state.prompt.state.cursor;
         frame.set_cursor_position((cx, cy));
     }
 


### PR DESCRIPTION
The goal is to inevitably switch from Ratatui, and start using Termwiz
with Termwiz widgets.

My hope is that this will clean up the UI code quite a bit,
as well as allow more features like re-interpreting terminal codes,
and perhaps using Termwiz's line editor with autocomplete for prompts.

This merely switches the "backend" of Ratatui to Termwiz.

TODO:
- [ ] Test on Mac
- [ ] Test on Windows
- [ ] Fix: hunks turn black when selected and extending beyond terminal
![image](https://github.com/user-attachments/assets/1f955ec2-ea19-46d7-adb0-ec4d735217da)