### PR TITLE
refactor: add new state.prompt() function and simplify event handling

### DIFF
--- a/benches/show.rs
+++ b/benches/show.rs
@@ -4,7 +4,11 @@ use ratatui::{backend::TestBackend, Terminal};
 
 fn show(c: &mut Criterion) {
     c.bench_function("show", |b| {
-        let mut terminal = Terminal::new(TermBackend::Test(TestBackend::new(80, 1000))).unwrap();
+        let mut terminal = Terminal::new(TermBackend::Test {
+            backend: TestBackend::new(80, 1000),
+            events: vec![],
+        })
+        .unwrap();
         b.iter(|| {
             gitu::run(
                 &gitu::cli::Args {

--- a/src/config.rs
+++ b/src/config.rs
@@ -205,6 +205,8 @@ pub(crate) fn init_test_config() -> Res<Config> {
         .map_err(Error::Config)?;
 
     config.general.always_show_help.enabled = false;
+    config.general.refresh_on_file_change.enabled = false;
+
     Ok(config)
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,4 @@
-use std::{fmt::Display, io, string, sync::mpsc};
-
-use crate::GituEvent;
+use std::{fmt::Display, io, string};
 
 #[derive(Debug)]
 pub enum Error {
@@ -9,8 +7,6 @@ pub enum Error {
     OpenRepo(git2::Error),
     FindGitDir(io::Error),
     Term(io::Error),
-    EventSendError(mpsc::SendError<GituEvent>),
-    EventRecvError(mpsc::RecvError),
     GitDirUtf8(string::FromUtf8Error),
     Config(figment::Error),
     FileWatcherGitignore(ignore::Error),
@@ -68,12 +64,6 @@ impl Display for Error {
             },
             Error::FindGitDir(e) => f.write_fmt(format_args!("Couldn't find git directory: {}", e)),
             Error::Term(e) => f.write_fmt(format_args!("Terminal error: {}", e)),
-            Error::EventSendError(e) => {
-                f.write_fmt(format_args!("Error when handling events: {}", e))
-            }
-            Error::EventRecvError(e) => {
-                f.write_fmt(format_args!("Error when handling events: {}", e))
-            }
             Error::GitDirUtf8(_e) => f.write_str("Git directory not valid UTF-8"),
             Error::Config(e) => f.write_fmt(format_args!("Configuration error: {}", e)),
             Error::FileWatcherGitignore(e) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,6 @@
-use std::{fmt::Display, io, string};
+use std::{fmt::Display, io, string, sync::mpsc};
+
+use crate::GituEvent;
 
 #[derive(Debug)]
 pub enum Error {
@@ -7,6 +9,8 @@ pub enum Error {
     OpenRepo(git2::Error),
     FindGitDir(io::Error),
     Term(io::Error),
+    EventSendError(mpsc::SendError<GituEvent>),
+    EventRecvError(mpsc::RecvError),
     GitDirUtf8(string::FromUtf8Error),
     Config(figment::Error),
     FileWatcherGitignore(ignore::Error),
@@ -63,6 +67,12 @@ impl Display for Error {
             },
             Error::FindGitDir(e) => f.write_fmt(format_args!("Couldn't find git directory: {}", e)),
             Error::Term(e) => f.write_fmt(format_args!("Terminal error: {}", e)),
+            Error::EventSendError(e) => {
+                f.write_fmt(format_args!("Error when handling events: {}", e))
+            }
+            Error::EventRecvError(e) => {
+                f.write_fmt(format_args!("Error when handling events: {}", e))
+            }
             Error::GitDirUtf8(_e) => f.write_str("Git directory not valid UTF-8"),
             Error::Config(e) => f.write_fmt(format_args!("Configuration error: {}", e)),
             Error::FileWatcherGitignore(e) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,6 +52,7 @@ pub enum Error {
     ListGitReferences(git2::Error),
     OpenLogFile(io::Error),
     PromptAborted,
+    NoMoreEvents,
 }
 
 impl std::error::Error for Error {}
@@ -144,6 +145,7 @@ impl Display for Error {
             }
             Error::OpenLogFile(e) => f.write_fmt(format_args!("Couldn't open log file: {}", e)),
             Error::PromptAborted => f.write_str("Aborted"),
+            Error::NoMoreEvents => unimplemented!(),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,6 +47,7 @@ pub enum Error {
     CouldntReadCmdOutput(io::Error),
     ListGitReferences(git2::Error),
     OpenLogFile(io::Error),
+    PromptAborted,
 }
 
 impl std::error::Error for Error {}
@@ -132,6 +133,7 @@ impl Display for Error {
                 f.write_fmt(format_args!("Couldn't list git references: {}", e))
             }
             Error::OpenLogFile(e) => f.write_fmt(format_args!("Couldn't open log file: {}", e)),
+            Error::PromptAborted => f.write_str("Aborted"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,3 +189,13 @@ fn handle_initial_send_keys(
 
     Ok(())
 }
+
+pub(crate) fn poll_term_event() -> Res<Option<GituEvent>> {
+    let event = if event::poll(Duration::from_millis(100)).map_err(Error::Term)? {
+        Some(GituEvent::Term(event::read().map_err(Error::Term)?))
+    } else {
+        None
+    };
+
+    Ok(event)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ pub fn run(args: &cli::Args, term: &mut Term) -> Res<()> {
         }
     }
 
-    state.update(term)?;
+    state.redraw_now(term)?;
 
     if args.print {
         return Ok(());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,7 @@ pub fn run(args: &cli::Args, term: &mut Term) -> Res<()> {
                 .map_err(Error::EventSendError)?;
         }
 
-        state.handle_events_timeout(term, Duration::from_millis(100))?;
+        state.handle_events(term)?;
     }
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@ pub enum GituEvent {
     Term(Event),
     FileUpdate,
     Refresh,
+    NoMoreEvents,
 }
 
 pub fn run(args: &cli::Args, term: &mut Term) -> Res<()> {

--- a/src/ops/checkout.rs
+++ b/src/ops/checkout.rs
@@ -2,13 +2,11 @@ use super::{selected_rev, Action, OpTrait};
 use crate::{
     items::TargetData,
     menu::arg::Arg,
-    prompt::PromptData,
     state::{PromptParams, State},
     term::Term,
     Res,
 };
 use std::{process::Command, rc::Rc};
-use tui_prompts::State as _;
 
 pub(crate) fn init_args() -> Vec<Arg> {
     vec![]
@@ -17,14 +15,17 @@ pub(crate) fn init_args() -> Vec<Arg> {
 pub(crate) struct Checkout;
 impl OpTrait for Checkout {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
-        Some(Rc::new(move |state: &mut State, _term: &mut Term| {
-            state.set_prompt(PromptParams {
-                prompt: "Checkout",
-                on_success: Box::new(checkout),
-                create_default_value: Box::new(selected_rev),
-                hide_menu: true,
-            });
+        Some(Rc::new(move |state: &mut State, term: &mut Term| {
+            let rev = state.prompt(
+                term,
+                &PromptParams {
+                    prompt: "Checkout",
+                    create_default_value: Box::new(selected_rev),
+                    ..Default::default()
+                },
+            )?;
 
+            checkout(state, term, &rev)?;
             Ok(())
         }))
     }
@@ -48,12 +49,16 @@ fn checkout(state: &mut State, term: &mut Term, rev: &str) -> Res<()> {
 pub(crate) struct CheckoutNewBranch;
 impl OpTrait for CheckoutNewBranch {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
-        Some(Rc::new(|state: &mut State, _term: &mut Term| {
-            state.close_menu();
-            state.prompt.set(PromptData {
-                prompt_text: "Create and checkout branch:".into(),
-                update_fn: Rc::new(checkout_new_branch_prompt_update),
-            });
+        Some(Rc::new(|state: &mut State, term: &mut Term| {
+            let branch_name = state.prompt(
+                term,
+                &PromptParams {
+                    prompt: "Create and checkout branch:",
+                    ..Default::default()
+                },
+            )?;
+
+            checkout_new_branch_prompt_update(state, term, &branch_name)?;
             Ok(())
         }))
     }
@@ -63,15 +68,15 @@ impl OpTrait for CheckoutNewBranch {
     }
 }
 
-fn checkout_new_branch_prompt_update(state: &mut State, term: &mut Term) -> Res<()> {
-    if state.prompt.state.status().is_done() {
-        let name = state.prompt.state.value().to_string();
-        state.prompt.reset(term)?;
+fn checkout_new_branch_prompt_update(
+    state: &mut State,
+    term: &mut Term,
+    branch_name: &str,
+) -> Res<()> {
+    let mut cmd = Command::new("git");
+    cmd.args(["checkout", "-b", branch_name]);
 
-        let mut cmd = Command::new("git");
-        cmd.args(["checkout", "-b", &name]);
-
-        state.run_cmd(term, &[], cmd)?;
-    }
+    state.close_menu();
+    state.run_cmd(term, &[], cmd)?;
     Ok(())
 }

--- a/src/ops/discard.rs
+++ b/src/ops/discard.rs
@@ -1,6 +1,6 @@
 use gitu_diff::Status;
 
-use super::{Action, OpTrait};
+use super::{confirm, Action, OpTrait};
 use crate::{git::diff::Diff, gitu_diff, items::TargetData, state::State};
 use std::{path::PathBuf, process::Command, rc::Rc};
 
@@ -31,7 +31,7 @@ impl OpTrait for Discard {
             _ => return None,
         };
 
-        Some(super::create_y_n_prompt(action, "Really discard?"))
+        Some(action)
     }
 
     fn is_target_op(&self) -> bool {
@@ -45,6 +45,8 @@ impl OpTrait for Discard {
 
 fn discard_branch(branch: String) -> Action {
     Rc::new(move |state, term| {
+        confirm(state, term, "Really discard? (y or n)")?;
+
         let mut cmd = Command::new("git");
         cmd.args(["branch", "-d"]);
         cmd.arg(&branch);
@@ -56,6 +58,8 @@ fn discard_branch(branch: String) -> Action {
 
 fn clean_file(file: PathBuf) -> Action {
     Rc::new(move |state, term| {
+        confirm(state, term, "Really discard? (y or n)")?;
+
         let mut cmd = Command::new("git");
         cmd.args(["clean", "--force"]);
         cmd.arg(&file);
@@ -67,6 +71,8 @@ fn clean_file(file: PathBuf) -> Action {
 
 fn rename_file(src: PathBuf, dest: PathBuf) -> Action {
     Rc::new(move |state, term| {
+        confirm(state, term, "Really discard? (y or n)")?;
+
         let mut cmd = Command::new("git");
         cmd.args(["mv", "--force"]);
         cmd.arg(&src);
@@ -79,6 +85,8 @@ fn rename_file(src: PathBuf, dest: PathBuf) -> Action {
 
 fn remove_file(file: PathBuf) -> Action {
     Rc::new(move |state, term| {
+        confirm(state, term, "Really discard? (y or n)")?;
+
         let mut cmd = Command::new("git");
         cmd.args(["rm", "--force"]);
         cmd.arg(&file);
@@ -90,6 +98,8 @@ fn remove_file(file: PathBuf) -> Action {
 
 fn checkout_file(file: PathBuf) -> Action {
     Rc::new(move |state, term| {
+        confirm(state, term, "Really discard? (y or n)")?;
+
         let mut cmd = Command::new("git");
         cmd.args(["checkout", "HEAD", "--"]);
         cmd.arg(&file);
@@ -101,6 +111,8 @@ fn checkout_file(file: PathBuf) -> Action {
 
 fn discard_unstaged_patch(diff: Rc<Diff>, file_i: usize, hunk_i: usize) -> Action {
     Rc::new(move |state, term| {
+        confirm(state, term, "Really discard? (y or n)")?;
+
         let mut cmd = Command::new("git");
         cmd.args(["apply", "--reverse"]);
 

--- a/src/ops/editor.rs
+++ b/src/ops/editor.rs
@@ -1,4 +1,4 @@
-use super::{Action, OpTrait};
+use super::{confirm, Action, OpTrait};
 use crate::{
     items::TargetData,
     menu::PendingMenu,
@@ -19,18 +19,11 @@ impl OpTrait for Quit {
 
             if menu == root_menu(&state.config) {
                 if state.screens.len() == 1 {
-                    let quit = Rc::new(|state: &mut State, _term: &mut Term| {
-                        state.quit = true;
-                        Ok(())
-                    });
-
-                    let mut action = if state.config.general.confirm_quit.enabled {
-                        super::create_y_n_prompt(quit, "Really quit?")
-                    } else {
-                        quit
+                    if state.config.general.confirm_quit.enabled {
+                        confirm(state, term, "Really quit? (y or n)")?;
                     };
 
-                    Rc::get_mut(&mut action).unwrap()(state, term)?;
+                    state.quit = true;
                 } else {
                     state.screens.pop();
                     if let Some(screen) = state.screens.last_mut() {
@@ -84,7 +77,7 @@ pub(crate) struct ToggleArg(pub String);
 impl OpTrait for ToggleArg {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
         let arg_name = self.0.clone();
-        Some(Rc::new(move |state, _term| {
+        Some(Rc::new(move |state, term| {
             let mut need_prompt = None;
             let mut default = None;
 
@@ -120,12 +113,16 @@ impl OpTrait for ToggleArg {
                 });
 
             if let Some(display) = need_prompt {
-                state.set_prompt(PromptParams {
-                    prompt: display,
-                    on_success: parse_and_set_arg,
-                    create_default_value: Box::new(move |_| default.clone()),
-                    hide_menu: false,
-                });
+                let arg = state.prompt(
+                    term,
+                    &PromptParams {
+                        prompt: display,
+                        create_default_value: Box::new(move |_| default.clone()),
+                        hide_menu: false,
+                    },
+                )?;
+
+                parse_and_set_arg(state, term, &arg)?;
             }
 
             Ok(())

--- a/src/ops/fetch.rs
+++ b/src/ops/fetch.rs
@@ -37,13 +37,16 @@ impl OpTrait for FetchAll {
 pub(crate) struct FetchElsewhere;
 impl OpTrait for FetchElsewhere {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
-        Some(Rc::new(move |state: &mut State, _term: &mut Term| {
-            state.set_prompt(PromptParams {
-                prompt: "Select remote",
-                on_success: Box::new(push_elsewhere),
-                ..Default::default()
-            });
+        Some(Rc::new(move |state: &mut State, term: &mut Term| {
+            let remote = state.prompt(
+                term,
+                &PromptParams {
+                    prompt: "Select remote",
+                    ..Default::default()
+                },
+            )?;
 
+            push_elsewhere(state, term, &remote)?;
             Ok(())
         }))
     }

--- a/src/ops/log.rs
+++ b/src/ops/log.rs
@@ -28,7 +28,14 @@ pub(crate) fn init_args() -> Vec<Arg> {
 pub(crate) struct LogCurrent;
 impl OpTrait for LogCurrent {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
-        Some(Rc::new(|state: &mut State, _term: &mut Term| {
+        Some(Rc::new(|state: &mut State, term: &mut Term| {
+            let answer = state.prompt(term, "Are you sure you want to view the log?")?;
+            log::debug!("Answer: {answer}");
+
+            let answer2 = state.prompt(term, "Are you really sure you want to view the log?")?;
+            log::debug!("Answer: {answer2}");
+
+            todo!("Remove this");
             goto_log_screen(state, None);
             Ok(())
         }))

--- a/src/ops/log.rs
+++ b/src/ops/log.rs
@@ -28,14 +28,7 @@ pub(crate) fn init_args() -> Vec<Arg> {
 pub(crate) struct LogCurrent;
 impl OpTrait for LogCurrent {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
-        Some(Rc::new(|state: &mut State, term: &mut Term| {
-            let answer = state.prompt(term, "Are you sure you want to view the log?")?;
-            log::debug!("Answer: {answer}");
-
-            let answer2 = state.prompt(term, "Are you really sure you want to view the log?")?;
-            log::debug!("Answer: {answer2}");
-
-            todo!("Remove this");
+        Some(Rc::new(|state: &mut State, _term: &mut Term| {
             goto_log_screen(state, None);
             Ok(())
         }))

--- a/src/ops/log.rs
+++ b/src/ops/log.rs
@@ -42,14 +42,17 @@ impl OpTrait for LogCurrent {
 pub(crate) struct LogOther;
 impl OpTrait for LogOther {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
-        Some(Rc::new(move |state: &mut State, _term: &mut Term| {
-            state.set_prompt(PromptParams {
-                prompt: "Log rev",
-                on_success: Box::new(log_other),
-                create_default_value: Box::new(selected_rev),
-                hide_menu: true,
-            });
+        Some(Rc::new(move |state: &mut State, term: &mut Term| {
+            let rev = state.prompt(
+                term,
+                &PromptParams {
+                    prompt: "Log rev",
+                    create_default_value: Box::new(selected_rev),
+                    ..Default::default()
+                },
+            )?;
 
+            log_other(state, term, &rev)?;
             Ok(())
         }))
     }

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -1,10 +1,6 @@
 use serde::{Deserialize, Serialize};
-use tui_prompts::State as _;
 
-use crate::{
-    cmd_log::CmdLogEntry, items::TargetData, menu::Menu, prompt::PromptData, state::State,
-    term::Term, Res,
-};
+use crate::{items::TargetData, menu::Menu, state::State, term::Term, Res};
 use std::{fmt::Display, rc::Rc};
 
 pub(crate) mod checkout;
@@ -188,34 +184,8 @@ impl Display for Menu {
     }
 }
 
-pub(crate) fn create_y_n_prompt(mut action: Action, prompt: &'static str) -> Action {
-    let update_fn = Rc::new(move |state: &mut State, term: &mut Term| {
-        if state.prompt.state.status().is_pending() {
-            match state.prompt.state.value() {
-                "y" => {
-                    Rc::get_mut(&mut action).unwrap()(state, term)?;
-                    state.prompt.reset(term)?;
-                }
-                "" => (),
-                _ => {
-                    state
-                        .current_cmd_log
-                        .push(CmdLogEntry::Error("Aborted".to_string()));
-                    state.prompt.reset(term)?;
-                }
-            }
-        }
-        Ok(())
-    });
-
-    Rc::new(move |state: &mut State, _term: &mut Term| {
-        state.prompt.set(PromptData {
-            prompt_text: format!("{} (y or n)", prompt).into(),
-            update_fn: update_fn.clone(),
-        });
-
-        Ok(())
-    })
+pub(crate) fn confirm(state: &mut State, term: &mut Term, prompt: &'static str) -> Res<()> {
+    state.confirm(term, prompt)
 }
 
 pub(crate) fn selected_rev(state: &State) -> Option<String> {

--- a/src/ops/pull.rs
+++ b/src/ops/pull.rs
@@ -23,16 +23,16 @@ impl OpTrait for PullFromPushRemote {
         Some(Rc::new(
             |state: &mut State, term: &mut Term| match get_push_remote(&state.repo)? {
                 None => {
-                    let mut prompt = Rc::new(move |state: &mut State, _term: &mut Term| {
-                        state.set_prompt(PromptParams {
+                    let push_remote_name = state.prompt(
+                        term,
+                        &PromptParams {
                             prompt: "Set pushRemote then pull",
-                            on_success: Box::new(set_push_remote_and_pull),
                             ..Default::default()
-                        });
+                        },
+                    )?;
 
-                        Ok(())
-                    });
-                    Rc::get_mut(&mut prompt).unwrap()(state, term)
+                    set_push_remote_and_pull(state, term, &push_remote_name)?;
+                    Ok(())
                 }
                 Some(push_remote) => {
                     let refspec = git::get_head_name(&state.repo)?;

--- a/src/ops/push.rs
+++ b/src/ops/push.rs
@@ -23,16 +23,16 @@ impl OpTrait for PushToPushRemote {
         Some(Rc::new(
             |state: &mut State, term: &mut Term| match get_push_remote(&state.repo)? {
                 None => {
-                    let mut prompt = Rc::new(move |state: &mut State, _term: &mut Term| {
-                        state.set_prompt(PromptParams {
+                    let push_remote_name = state.prompt(
+                        term,
+                        &PromptParams {
                             prompt: "Set pushRemote then push",
-                            on_success: Box::new(set_push_remote_and_push),
                             ..Default::default()
-                        });
+                        },
+                    )?;
 
-                        Ok(())
-                    });
-                    Rc::get_mut(&mut prompt).unwrap()(state, term)
+                    set_push_remote_and_push(state, term, &push_remote_name)?;
+                    Ok(())
                 }
                 Some(push_remote) => {
                     let head_ref = git::get_head_name(&state.repo)?;
@@ -72,13 +72,16 @@ impl OpTrait for PushToUpstream {
         Some(Rc::new(
             |state: &mut State, term: &mut Term| match get_upstream_components(&state.repo)? {
                 None => {
-                    let mut prompt = Rc::new(move |state: &mut State, _term: &mut Term| {
-                        state.set_prompt(PromptParams {
-                            prompt: "Set upstream then push",
-                            on_success: Box::new(set_upstream_and_push),
-                            ..Default::default()
-                        });
+                    let mut prompt = Rc::new(move |state: &mut State, term: &mut Term| {
+                        let upstream_name = state.prompt(
+                            term,
+                            &PromptParams {
+                                prompt: "Set upstream then push",
+                                ..Default::default()
+                            },
+                        )?;
 
+                        set_upstream_and_push(state, term, &upstream_name)?;
                         Ok(())
                     });
                     Rc::get_mut(&mut prompt).unwrap()(state, term)
@@ -112,13 +115,16 @@ fn set_upstream_and_push(state: &mut State, term: &mut Term, upstream_name: &str
 pub(crate) struct PushToElsewhere;
 impl OpTrait for PushToElsewhere {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
-        Some(Rc::new(move |state: &mut State, _term: &mut Term| {
-            state.set_prompt(PromptParams {
-                prompt: "Select remote",
-                on_success: Box::new(push_elsewhere),
-                ..Default::default()
-            });
+        Some(Rc::new(move |state: &mut State, term: &mut Term| {
+            let remote = state.prompt(
+                term,
+                &PromptParams {
+                    prompt: "Select remote",
+                    ..Default::default()
+                },
+            )?;
 
+            push_elsewhere(state, term, &remote)?;
             Ok(())
         }))
     }

--- a/src/ops/rebase.rs
+++ b/src/ops/rebase.rs
@@ -67,14 +67,17 @@ impl OpTrait for RebaseAbort {
 pub(crate) struct RebaseElsewhere;
 impl OpTrait for RebaseElsewhere {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
-        Some(Rc::new(move |state: &mut State, _term: &mut Term| {
-            state.set_prompt(PromptParams {
-                prompt: "Rebase onto",
-                on_success: Box::new(rebase_elsewhere),
-                create_default_value: Box::new(selected_rev),
-                hide_menu: true,
-            });
+        Some(Rc::new(move |state: &mut State, term: &mut Term| {
+            let rev = state.prompt(
+                term,
+                &PromptParams {
+                    prompt: "Rebase onto",
+                    create_default_value: Box::new(selected_rev),
+                    ..Default::default()
+                },
+            )?;
 
+            rebase_elsewhere(state, term, &rev)?;
             Ok(())
         }))
     }

--- a/src/ops/reset.rs
+++ b/src/ops/reset.rs
@@ -15,14 +15,17 @@ pub(crate) fn init_args() -> Vec<Arg> {
 pub(crate) struct ResetSoft;
 impl OpTrait for ResetSoft {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
-        Some(Rc::new(move |state: &mut State, _term: &mut Term| {
-            state.set_prompt(PromptParams {
-                prompt: "Soft reset to",
-                on_success: Box::new(reset_soft),
-                create_default_value: Box::new(selected_rev),
-                hide_menu: true,
-            });
+        Some(Rc::new(move |state: &mut State, term: &mut Term| {
+            let rev = state.prompt(
+                term,
+                &PromptParams {
+                    prompt: "Soft reset to",
+                    create_default_value: Box::new(selected_rev),
+                    ..Default::default()
+                },
+            )?;
 
+            reset_soft(state, term, &rev)?;
             Ok(())
         }))
     }
@@ -45,14 +48,17 @@ fn reset_soft(state: &mut State, term: &mut Term, input: &str) -> Res<()> {
 pub(crate) struct ResetMixed;
 impl OpTrait for ResetMixed {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
-        Some(Rc::new(move |state: &mut State, _term: &mut Term| {
-            state.set_prompt(PromptParams {
-                prompt: "Mixed reset to",
-                on_success: Box::new(reset_mixed),
-                create_default_value: Box::new(selected_rev),
-                hide_menu: true,
-            });
+        Some(Rc::new(move |state: &mut State, term: &mut Term| {
+            let rev = state.prompt(
+                term,
+                &PromptParams {
+                    prompt: "Mixed reset to",
+                    create_default_value: Box::new(selected_rev),
+                    ..Default::default()
+                },
+            )?;
 
+            reset_mixed(state, term, &rev)?;
             Ok(())
         }))
     }
@@ -75,14 +81,17 @@ fn reset_mixed(state: &mut State, term: &mut Term, input: &str) -> Res<()> {
 pub(crate) struct ResetHard;
 impl OpTrait for ResetHard {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
-        Some(Rc::new(move |state: &mut State, _term: &mut Term| {
-            state.set_prompt(PromptParams {
-                prompt: "Hard reset to",
-                on_success: Box::new(reset_hard),
-                create_default_value: Box::new(selected_rev),
-                hide_menu: true,
-            });
+        Some(Rc::new(move |state: &mut State, term: &mut Term| {
+            let rev = state.prompt(
+                term,
+                &PromptParams {
+                    prompt: "Hard reset to",
+                    create_default_value: Box::new(selected_rev),
+                    ..Default::default()
+                },
+            )?;
 
+            reset_hard(state, term, &rev)?;
             Ok(())
         }))
     }

--- a/src/ops/revert.rs
+++ b/src/ops/revert.rs
@@ -59,14 +59,17 @@ impl OpTrait for RevertContinue {
 pub(crate) struct RevertCommit;
 impl OpTrait for RevertCommit {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
-        Some(Rc::new(move |state: &mut State, _term: &mut Term| {
-            state.set_prompt(PromptParams {
-                prompt: "Revert commit",
-                on_success: Box::new(revert_commit),
-                create_default_value: Box::new(selected_rev),
-                hide_menu: true,
-            });
+        Some(Rc::new(move |state: &mut State, term: &mut Term| {
+            let commit = state.prompt(
+                term,
+                &PromptParams {
+                    prompt: "Revert commit",
+                    create_default_value: Box::new(selected_rev),
+                    ..Default::default()
+                },
+            )?;
 
+            revert_commit(state, term, &commit)?;
             Ok(())
         }))
     }

--- a/src/ops/stash.rs
+++ b/src/ops/stash.rs
@@ -20,13 +20,16 @@ pub(crate) fn init_args() -> Vec<Arg> {
 pub(crate) struct Stash;
 impl OpTrait for Stash {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
-        Some(Rc::new(move |state: &mut State, _term: &mut Term| {
-            state.set_prompt(PromptParams {
-                prompt: "Stash message",
-                on_success: Box::new(stash_push),
-                ..Default::default()
-            });
+        Some(Rc::new(move |state: &mut State, term: &mut Term| {
+            let message = state.prompt(
+                term,
+                &PromptParams {
+                    prompt: "Stash message",
+                    ..Default::default()
+                },
+            )?;
 
+            stash_push(state, term, &message)?;
             Ok(())
         }))
     }
@@ -52,13 +55,16 @@ fn stash_push(state: &mut State, term: &mut Term, input: &str) -> Res<()> {
 pub(crate) struct StashIndex;
 impl OpTrait for StashIndex {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
-        Some(Rc::new(move |state: &mut State, _term: &mut Term| {
-            state.set_prompt(PromptParams {
-                prompt: "Stash message",
-                on_success: Box::new(stash_push_index),
-                ..Default::default()
-            });
+        Some(Rc::new(move |state: &mut State, term: &mut Term| {
+            let message = state.prompt(
+                term,
+                &PromptParams {
+                    prompt: "Stash message",
+                    ..Default::default()
+                },
+            )?;
 
+            stash_push_index(state, term, &message)?;
             Ok(())
         }))
     }
@@ -90,16 +96,15 @@ impl OpTrait for StashWorktree {
                 return Err(Error::StashWorkTreeEmpty);
             }
 
-            let mut create_prompt = Rc::new(move |state: &mut State, _term: &mut Term| {
-                state.set_prompt(PromptParams {
+            let message = state.prompt(
+                term,
+                &PromptParams {
                     prompt: "Stash message",
-                    on_success: Box::new(stash_worktree),
                     ..Default::default()
-                });
+                },
+            )?;
 
-                Ok(())
-            });
-            Rc::get_mut(&mut create_prompt).unwrap()(state, term)?;
+            stash_worktree(state, term, &message)?;
             Ok(())
         }))
     }
@@ -183,13 +188,16 @@ fn is_something_staged(repo: &Repository) -> Res<bool> {
 pub(crate) struct StashKeepIndex;
 impl OpTrait for StashKeepIndex {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
-        Some(Rc::new(move |state: &mut State, _term: &mut Term| {
-            state.set_prompt(PromptParams {
-                prompt: "Stash message",
-                on_success: Box::new(stash_push_keep_index),
-                ..Default::default()
-            });
+        Some(Rc::new(move |state: &mut State, term: &mut Term| {
+            let message = state.prompt(
+                term,
+                &PromptParams {
+                    prompt: "Stash message",
+                    ..Default::default()
+                },
+            )?;
 
+            stash_push_keep_index(state, term, &message)?;
             Ok(())
         }))
     }
@@ -215,14 +223,17 @@ fn stash_push_keep_index(state: &mut State, term: &mut Term, input: &str) -> Res
 pub(crate) struct StashPop;
 impl OpTrait for StashPop {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
-        Some(Rc::new(move |state: &mut State, _term: &mut Term| {
-            state.set_prompt(PromptParams {
-                prompt: "Pop stash",
-                on_success: Box::new(stash_pop),
-                create_default_value: Box::new(selected_stash),
-                hide_menu: true,
-            });
+        Some(Rc::new(move |state: &mut State, term: &mut Term| {
+            let input = state.prompt(
+                term,
+                &PromptParams {
+                    prompt: "Pop stash",
+                    create_default_value: Box::new(selected_stash),
+                    ..Default::default()
+                },
+            )?;
 
+            stash_pop(state, term, &input)?;
             Ok(())
         }))
     }
@@ -245,14 +256,17 @@ fn stash_pop(state: &mut State, term: &mut Term, input: &str) -> Res<()> {
 pub(crate) struct StashApply;
 impl OpTrait for StashApply {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
-        Some(Rc::new(move |state: &mut State, _term: &mut Term| {
-            state.set_prompt(PromptParams {
-                prompt: "Apply stash",
-                on_success: Box::new(stash_apply),
-                create_default_value: Box::new(selected_stash),
-                hide_menu: true,
-            });
+        Some(Rc::new(move |state: &mut State, term: &mut Term| {
+            let input = state.prompt(
+                term,
+                &PromptParams {
+                    prompt: "Apply stash",
+                    create_default_value: Box::new(selected_stash),
+                    ..Default::default()
+                },
+            )?;
 
+            stash_apply(state, term, &input)?;
             Ok(())
         }))
     }
@@ -275,14 +289,17 @@ fn stash_apply(state: &mut State, term: &mut Term, input: &str) -> Res<()> {
 pub(crate) struct StashDrop;
 impl OpTrait for StashDrop {
     fn get_action(&self, _target: Option<&TargetData>) -> Option<Action> {
-        Some(Rc::new(move |state: &mut State, _term: &mut Term| {
-            state.set_prompt(PromptParams {
-                prompt: "Drop stash",
-                on_success: Box::new(stash_drop),
-                create_default_value: Box::new(selected_stash),
-                hide_menu: true,
-            });
+        Some(Rc::new(move |state: &mut State, term: &mut Term| {
+            let input = state.prompt(
+                term,
+                &PromptParams {
+                    prompt: "Drop stash",
+                    create_default_value: Box::new(selected_stash),
+                    ..Default::default()
+                },
+            )?;
 
+            stash_drop(state, term, &input)?;
             Ok(())
         }))
     }

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -1,12 +1,11 @@
 use super::Res;
-use crate::{error::Error, ops::Action};
+use crate::error::Error;
 use ratatui::{backend::Backend, Terminal};
 use std::borrow::Cow;
 use tui_prompts::{State as _, TextState};
 
 pub(crate) struct PromptData {
     pub(crate) prompt_text: Cow<'static, str>,
-    pub(crate) update_fn: Action,
 }
 
 pub(crate) struct Prompt {

--- a/src/tests/commit.rs
+++ b/src/tests/commit.rs
@@ -9,7 +9,7 @@ fn commit_instant_fixup() {
     commit(ctx.dir.path(), "instant_fixup.txt", "mistake\n");
     fs::write(ctx.dir.child("instant_fixup.txt"), "fixed\n").unwrap();
     run(ctx.dir.path(), &["git", "add", "."]);
-    state.update(&mut ctx.term, &keys("gjjjjjcF")).unwrap();
+    ctx.update(&mut state, keys("gjjjjjcF"));
 
     insta::assert_snapshot!(ctx.redact_buffer());
 }
@@ -28,7 +28,7 @@ fn commit_instant_fixup_stashes_changes_and_keeps_empty() {
     fs::write(ctx.dir.child("instant_fixup.txt"), "fixed\n").unwrap();
     run(ctx.dir.path(), &["git", "add", "."]);
     fs::write(ctx.dir.child("instant_fixup.txt"), "unstaged\n").unwrap();
-    state.update(&mut ctx.term, &keys("gjjjjjjjjjcF")).unwrap();
+    ctx.update(&mut state, keys("gjjjjjjjjjcF"));
 
     insta::assert_snapshot!(ctx.redact_buffer());
 }

--- a/src/tests/editor.rs
+++ b/src/tests/editor.rs
@@ -17,54 +17,42 @@ fn setup_scroll() -> (TestContext, crate::state::State) {
     }
 
     let mut state = ctx.init_state();
-    state
-        .update(&mut ctx.term, &keys("jjjj<tab>k<tab>k<tab>"))
-        .unwrap();
+    ctx.update(&mut state, keys("jjjj<tab>k<tab>k<tab>"));
     (ctx, state)
 }
 
 #[test]
 fn scroll_down() {
     let (mut ctx, mut state) = setup_scroll();
-
-    state.update(&mut ctx.term, &keys("<ctrl+d>")).unwrap();
-
+    ctx.update(&mut state, keys("<ctrl+d>"));
     insta::assert_snapshot!(ctx.redact_buffer());
 }
 
 #[test]
 fn scroll_past_selection() {
     let (mut ctx, mut state) = setup_scroll();
-
-    state
-        .update(&mut ctx.term, &keys("<ctrl+d><ctrl+d><ctrl+d>"))
-        .unwrap();
-
+    ctx.update(&mut state, keys("<ctrl+d><ctrl+d><ctrl+d>"));
     insta::assert_snapshot!(ctx.redact_buffer());
 }
 
 #[test]
 fn move_prev_sibling() {
     let (mut ctx, mut state) = setup_scroll();
-    state
-        .update(&mut ctx.term, &keys("<alt+k><alt+k>"))
-        .unwrap();
+    ctx.update(&mut state, keys("<alt+k><alt+k>"));
     insta::assert_snapshot!(ctx.redact_buffer());
 }
 
 #[test]
 fn move_next_sibling() {
     let (mut ctx, mut state) = setup_scroll();
-    state.update(&mut ctx.term, &keys("<alt+j>")).unwrap();
+    ctx.update(&mut state, keys("<alt+j>"));
     insta::assert_snapshot!(ctx.redact_buffer());
 }
 
 #[test]
 fn move_next_then_parent_section() {
     let (mut ctx, mut state) = setup_scroll();
-    state
-        .update(&mut ctx.term, &keys("<alt+j><alt+h>"))
-        .unwrap();
+    ctx.update(&mut state, keys("<alt+j><alt+h>"));
     insta::assert_snapshot!(ctx.redact_buffer());
 }
 

--- a/src/tests/helpers/ui.rs
+++ b/src/tests/helpers/ui.rs
@@ -95,7 +95,7 @@ impl TestContext {
         )
         .unwrap();
 
-        state.update(&mut self.term).unwrap();
+        state.redraw_now(&mut self.term).unwrap();
         state
     }
 

--- a/src/tests/helpers/ui.rs
+++ b/src/tests/helpers/ui.rs
@@ -1,6 +1,7 @@
 use crate::{
     cli::Args,
     config::{self, Config},
+    error::Error,
     key_parser::parse_keys,
     state::State,
     term::{Term, TermBackend},
@@ -113,9 +114,14 @@ impl TestContext {
             self.sender.as_mut().unwrap().send(event).unwrap();
         }
 
-        state
-            .handle_events_timeout(&mut self.term, Duration::ZERO)
+        self.sender
+            .as_mut()
+            .unwrap()
+            .send(GituEvent::NoMoreEvents)
             .unwrap();
+
+        let result = state.handle_events_timeout(&mut self.term, Duration::ZERO);
+        assert!(matches!(result, Err(Error::NoMoreEvents)));
     }
 
     pub fn redact_buffer(&self) -> String {

--- a/src/tests/helpers/ui.rs
+++ b/src/tests/helpers/ui.rs
@@ -15,7 +15,6 @@ use std::{
     path::PathBuf,
     rc::Rc,
     sync::mpsc::{self, Sender},
-    time::Duration,
 };
 use temp_dir::TempDir;
 
@@ -102,9 +101,7 @@ impl TestContext {
             .send(GituEvent::Refresh)
             .unwrap();
 
-        state
-            .handle_events_timeout(&mut self.term, Duration::ZERO)
-            .unwrap();
+        state.handle_events(&mut self.term).unwrap();
 
         state
     }
@@ -120,7 +117,7 @@ impl TestContext {
             .send(GituEvent::NoMoreEvents)
             .unwrap();
 
-        let result = state.handle_events_timeout(&mut self.term, Duration::ZERO);
+        let result = state.handle_events(&mut self.term);
         assert!(matches!(result, Err(Error::NoMoreEvents)));
     }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -47,7 +47,7 @@ fn help_menu() {
     let mut ctx = TestContext::setup_init();
 
     let mut state = ctx.init_state();
-    state.update(&mut ctx.term, &keys("h")).unwrap();
+    ctx.update(&mut state, keys("h"));
     insta::assert_snapshot!(ctx.redact_buffer());
 }
 
@@ -213,7 +213,7 @@ fn hide_untracked() {
     let mut config = state.repo.config().unwrap();
     config.set_str("status.showUntrackedFiles", "off").unwrap();
 
-    state.update(&mut ctx.term, &keys("g")).unwrap();
+    ctx.update(&mut state, keys("g"));
     insta::assert_snapshot!(ctx.redact_buffer());
 }
 
@@ -293,11 +293,11 @@ fn updated_externally() {
     fs::write(ctx.dir.child("b"), "test\n").unwrap();
 
     let mut state = ctx.init_state();
-    state.update(&mut ctx.term, &keys("jjsj")).unwrap();
+    ctx.update(&mut state, keys("jjsj"));
 
     fs::write(ctx.dir.child("a"), "test\n").unwrap();
 
-    state.update(&mut ctx.term, &keys("g")).unwrap();
+    ctx.update(&mut state, keys("g"));
     insta::assert_snapshot!(ctx.redact_buffer());
 }
 
@@ -373,7 +373,7 @@ fn crlf_diff() {
 
     commit(ctx.dir.path(), "crlf.txt", "unchanged\r\nunchanged\r\n");
     fs::write(ctx.dir.child("crlf.txt"), "unchanged\r\nchanged\r\n").unwrap();
-    state.update(&mut ctx.term, &keys("g")).unwrap();
+    ctx.update(&mut state, keys("g"));
 
     insta::assert_snapshot!(ctx.redact_buffer());
 }
@@ -385,7 +385,7 @@ fn tab_diff() {
 
     commit(ctx.dir.path(), "tab.txt", "this has no tab prefixed\n");
     fs::write(ctx.dir.child("tab.txt"), "\tthis has a tab prefixed\n").unwrap();
-    state.update(&mut ctx.term, &keys("g")).unwrap();
+    ctx.update(&mut state, keys("g"));
 
     insta::assert_snapshot!(ctx.redact_buffer());
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -283,7 +283,7 @@ mod checkout {
 
     #[test]
     pub(crate) fn checkout_new_branch() {
-        snapshot!(TestContext::setup_clone(), "bcf<esc>bcx<enter>");
+        snapshot!(TestContext::setup_clone(), "bcf<esc>cx<enter>");
     }
 }
 

--- a/src/tests/snapshots/gitu__tests__discard__discard_branch_no.snap
+++ b/src/tests/snapshots/gitu__tests__discard__discard_branch_no.snap
@@ -20,6 +20,6 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
-────────────────────────────────────────────────────────────────────────────────|
-! Aborted                                                                       |
-styles_hash: ee80f20b0cb8119a
+                                                                                |
+                                                                                |
+styles_hash: 8aeb733dddf67818

--- a/src/tests/snapshots/gitu__tests__pull__pull_setup_push_remote.snap
+++ b/src/tests/snapshots/gitu__tests__pull__pull_setup_push_remote.snap
@@ -11,15 +11,15 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
 Pull                    Arguments                                               |
 p from origin           -r Rebase local commits (--rebase)                      |
 u from origin/main                                                              |
 e from elsewhere                                                                |
 q/<esc> Quit/Close                                                              |
-────────────────────────────────────────────────────────────────────────────────|
-$ git pull origin refs/heads/main                                               |
-From                                                                            |
- * branch            main       -> FETCH_HEAD                                   |
-Already up to date.                                                             |
-styles_hash: 58b8068f5146eed2
+styles_hash: bfa894f169425746

--- a/src/tests/snapshots/gitu__tests__pull__pull_setup_upstream.snap
+++ b/src/tests/snapshots/gitu__tests__pull__pull_setup_upstream.snap
@@ -9,17 +9,17 @@ expression: ctx.redact_buffer()
  b66a0bf main new-branch origin/main add initial-file                           |
                                                                                 |
                                                                                 |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
 Pull                            Arguments                                       |
 p pushRemote, setting that      -r Rebase local commits (--rebase)              |
 u from main                                                                     |
 e from elsewhere                                                                |
 q/<esc> Quit/Close                                                              |
-────────────────────────────────────────────────────────────────────────────────|
-$ git branch --set-upstream-to main                                             |
-branch 'new-branch' set up to track 'main'.                                     |
-$ git pull . refs/heads/main                                                    |
-From .                                                                          |
- * branch            main       -> FETCH_HEAD                                   |
-Already up to date.                                                             |
-styles_hash: 9b65c93f218c4e5c
+styles_hash: 135771421537ce83

--- a/src/tests/snapshots/gitu__tests__push__push_setup_push_remote.snap
+++ b/src/tests/snapshots/gitu__tests__push__push_setup_push_remote.snap
@@ -13,13 +13,13 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
+                                                                                |
+                                                                                |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
 Push                    Arguments                                               |
 p to origin             -n Dry run (--dry-run)                                  |
 u to origin/main        -F Force (--force)                                      |
 e to elsewhere          -f Force with lease (--force-with-lease)                |
 q/<esc> Quit/Close      -h Disable hooks (--no-verify)                          |
-────────────────────────────────────────────────────────────────────────────────|
-$ git push origin refs/heads/main:refs/heads/main                               |
-Everything up-to-date                                                           |
-styles_hash: b4add50771a9adbe
+styles_hash: b0f9b30d052cdc2e

--- a/src/tests/snapshots/gitu__tests__push__push_setup_upstream.snap
+++ b/src/tests/snapshots/gitu__tests__push__push_setup_upstream.snap
@@ -10,16 +10,16 @@ expression: ctx.redact_buffer()
  b66a0bf origin/main add initial-file                                           |
                                                                                 |
                                                                                 |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
 Push                            Arguments                                       |
 p pushRemote, setting that      -n Dry run (--dry-run)                          |
 u to main                       -F Force (--force)                              |
 e to elsewhere                  -f Force with lease (--force-with-lease)        |
 q/<esc> Quit/Close              -h Disable hooks (--no-verify)                  |
-────────────────────────────────────────────────────────────────────────────────|
-$ git branch --set-upstream-to main                                             |
-branch 'new-branch' set up to track 'main'.                                     |
-$ git push . refs/heads/new-branch:refs/heads/main                              |
-To .                                                                            |
-   b66a0bf..e7eb2bd  new-branch -> main                                         |
-styles_hash: 26e2aff5c0eae868
+styles_hash: 4ca26e8a717c548e


### PR DESCRIPTION
aims to enable: https://github.com/altsem/gitu/pull/350, and simplify the already existing use-cases.

TODO:
- Tests aren't passing
- Make it prettier? There's a bit much shared logic between the update/prompt fns