### PR TITLE
feat: FileWatcher now ignores changes from patterns in .gitignore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,6 @@ dependencies = [
  "figment",
  "git-version",
  "git2",
- "ignore",
  "insta",
  "itertools 0.14.0",
  "log",
@@ -732,19 +731,6 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
-name = "globset"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
-dependencies = [
- "aho-corasick",
- "bstr",
- "log",
- "regex-automata",
- "regex-syntax",
-]
 
 [[package]]
 name = "half"
@@ -954,22 +940,6 @@ checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
-]
-
-[[package]]
-name = "ignore"
-version = "0.4.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
-dependencies = [
- "crossbeam-deque",
- "globset",
- "log",
- "memchr",
- "regex-automata",
- "same-file",
- "walkdir",
- "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ etcetera = "0.10.0"
 figment = { version = "0.10.19", features = ["toml"] }
 git-version = "0.3.9"
 git2 = { version = "0.20.1", default-features = false }
-ignore = "0.4.23"
 itertools = "0.14.0"
 log = "0.4.27"
 nom = "7.1.3"

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,7 +9,6 @@ pub enum Error {
     Term(io::Error),
     GitDirUtf8(string::FromUtf8Error),
     Config(figment::Error),
-    FileWatcherGitignore(ignore::Error),
     FileWatcher(notify::Error),
     ReadRebaseStatusFile(io::Error),
     ReadBranchName(io::Error),
@@ -64,9 +63,6 @@ impl Display for Error {
             Error::Term(e) => f.write_fmt(format_args!("Terminal error: {}", e)),
             Error::GitDirUtf8(_e) => f.write_str("Git directory not valid UTF-8"),
             Error::Config(e) => f.write_fmt(format_args!("Configuration error: {}", e)),
-            Error::FileWatcherGitignore(e) => {
-                f.write_fmt(format_args!("File watcher gitignore error: {}", e))
-            }
             Error::FileWatcher(e) => f.write_fmt(format_args!("File watcher error: {}", e)),
             Error::ReadRebaseStatusFile(e) => {
                 f.write_fmt(format_args!("Couldn't read rebase status file: {}", e))

--- a/src/file_watcher.rs
+++ b/src/file_watcher.rs
@@ -1,29 +1,28 @@
-use crate::{error::Error, Res};
-use ignore::gitignore::GitignoreBuilder;
-use notify::{Event, EventKind, RecursiveMode, Watcher};
+use crate::{error::Error, open_repo, Res};
+use ignore::gitignore::{gitconfig_excludes_path, GitignoreBuilder, Gitignore};
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use std::{
     path::Path,
+    path::PathBuf,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
-    thread,
 };
 
 pub struct FileWatcher {
+    _watcher: RecommendedWatcher,
     pending_updates: Arc<AtomicBool>,
 }
 
 impl FileWatcher {
-    pub fn new(path: &Path) -> Res<Self> {
+    pub fn new(repo_dir: &Path) -> Res<Self> {
         let pending_updates = Arc::new(AtomicBool::new(false));
         let pending_updates_w = pending_updates.clone();
 
-        let gitignore = GitignoreBuilder::new(path)
-            .add_line(None, super::LOG_FILE_NAME)
-            .map_err(Error::FileWatcherGitignore)?
-            .build()
-            .unwrap();
+        let path_buf = repo_dir.to_owned();
+        let path_buf_copy = path_buf.clone();
+        let mut gitignore = build_gitignore(repo_dir)?;
 
         let mut watcher = notify::recommended_watcher(move |res: Result<Event, notify::Error>| {
             if let Ok(event) = res {
@@ -32,7 +31,20 @@ impl FileWatcher {
                 }
 
                 for path in event.paths {
-                    if !gitignore.matched(&path, path.is_dir()).is_ignore() {
+                    if path
+                        .file_name()
+                        .map_or(false, |name| name == ".gitignore")
+                    {
+                        log::info!("Rebuilding gitignore ruleset");
+                        if let Ok(new_gitignore) = build_gitignore(&path_buf_copy) {
+                            gitignore = new_gitignore;
+                        }
+                    }
+
+                    if !gitignore
+                        .matched_path_or_any_parents(&path, path.is_dir())
+                        .is_ignore()
+                    {
                         log::info!("File changed: {:?}", path);
                         pending_updates_w.store(true, Ordering::Relaxed);
                         break;
@@ -42,17 +54,18 @@ impl FileWatcher {
         })
         .map_err(Error::FileWatcher)?;
 
-        let path_buf = path.to_owned();
-        thread::spawn(move || {
-            if let Err(err) = watcher
-                .watch(path_buf.as_ref(), RecursiveMode::Recursive)
-                .map_err(Error::FileWatcher)
-            {
-                log::error!("Couldn't start file-watcher due to: {}", err);
-            }
-        });
+        watcher
+            .watch(&path_buf, RecursiveMode::Recursive)
+            .map_err(Error::FileWatcher)?;
+        log::info!(
+            "File watcher started (kind: {:?})",
+            RecommendedWatcher::kind()
+        );
 
-        Ok(Self { pending_updates })
+        Ok(Self {
+            _watcher: watcher,
+            pending_updates,
+        })
     }
 
     pub fn pending_updates(&self) -> bool {
@@ -65,4 +78,33 @@ fn is_changed(event: &Event) -> bool {
         event.kind,
         EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
     )
+}
+
+fn build_gitignore(path: &Path) -> Res<Gitignore> {
+    let mut gitignore_builder = GitignoreBuilder::new(path);
+    for gitignore_path in repo_gitignore_paths(path)? {
+        gitignore_builder.add(gitignore_path);
+    }
+    gitignore_builder.add_line(None, super::LOG_FILE_NAME).ok();
+    gitignore_builder
+        .build()
+        .map_err(Error::FileWatcherGitignore)
+}
+
+fn repo_gitignore_paths(repo_dir: &Path) -> Res<Vec<PathBuf>> {
+    let mut gitignore_paths = gitconfig_excludes_path().map_or_else(|| vec![], |path| vec![path]);
+    gitignore_paths
+        .extend(
+            open_repo(repo_dir)?
+                .index()
+                .map_err(Error::OpenRepo)?
+                .iter()
+                .filter_map(|entry| {
+                    match std::str::from_utf8(&entry.path).map(Path::new) {
+                        Ok(path) if path.file_name() == Some(std::ffi::OsStr::new(".gitignore")) => Some(path.to_path_buf()),
+                        _ => None
+                    }
+                })
+        );
+    Ok(gitignore_paths)
 }


### PR DESCRIPTION
`FileWatcher` will build a gitignore ruleset from all `.gitignore` files in the repo and any global `.gitignore`, and use this to ignore file change events. This prevents a lot of `FileUpdate` events being generated when ignored items like build folders change, which may have been contributing to freezes.

If a change is detected involving a `.gitignore` file, the ruleset is rebuilt.

Changes are also now no longer watched from a thread, which caused problems with some watcher implementations such as `Fsevents` on macOS.

Fixes #359
Fixes #358