### PR TITLE
feat: wrap lines longer than the terminal width

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ pretty_assertions = "1.4.0"
 temp-dir = "0.1.13"
 criterion = "0.5.1"
 insta = "1.42.2"
-unicode-width = "0.2.0"
 
 [profile.release]
 strip = true
@@ -64,3 +63,4 @@ tree-sitter-elixir = "=0.1.1"
 regex = "1.11.1"
 strip-ansi-escapes = "0.2.1"
 unicode-segmentation = "1.12.0"
+unicode-width = "0.2.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,6 +48,8 @@ pub struct StyleConfig {
     pub selection_line: StyleConfigEntry,
     pub selection_bar: SymbolStyleConfigEntry,
     pub selection_area: StyleConfigEntry,
+    pub wrap_indicator: SymbolStyleConfigEntry,
+    pub collapsed_indicator: SymbolStyleConfigEntry,
 
     pub hash: StyleConfigEntry,
     pub branch: StyleConfigEntry,

--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -65,6 +65,8 @@ selection_line = { mods = "BOLD" }
 # You may want to set `selection_area.bg` to a nice background color.
 # Looks horrible with regular terminal colors, so is therefore not set.
 selection_area = {}
+wrap_indicator = { symbol = "↪", fg = "grey", mods = "DIM" }
+collapsed_indicator = { symbol = "…", fg = "grey", mods = "DIM" }
 
 hash = { fg = "yellow" }
 branch = { fg = "green" }

--- a/src/screen/mod.rs
+++ b/src/screen/mod.rs
@@ -384,6 +384,9 @@ impl Widget for &Screen {
             }
 
             line_index += height;
+            if line_index >= area.height {
+                break;
+            }
         }
     }
 }

--- a/src/screen/mod.rs
+++ b/src/screen/mod.rs
@@ -354,11 +354,9 @@ impl Widget for &Screen {
                 if self.line_index[self.cursor] == line.item_index {
                     buf.set_style(indented_line_area, &style.selection_line);
                 } else {
-                    for i in 0..height {
-                        buf[(SCREEN_GUTTER_COLUMN_CURSOR, line_index + i)]
-                            .set_char(style.selection_bar.symbol)
-                            .set_style(&style.selection_bar);
-                    }
+                    buf[(SCREEN_GUTTER_COLUMN_CURSOR, line_index)]
+                        .set_char(style.selection_bar.symbol)
+                        .set_style(&style.selection_bar);
                 }
             }
 
@@ -380,11 +378,9 @@ impl Widget for &Screen {
             }
 
             if self.line_index[self.cursor] == line.item_index {
-                for i in 0..height {
-                    buf[(SCREEN_GUTTER_COLUMN_CURSOR, line_index + i as u16)]
-                        .set_char(style.cursor.symbol)
-                        .set_style(&style.cursor);
-                }
+                buf[(SCREEN_GUTTER_COLUMN_CURSOR, line_index)]
+                    .set_char(style.cursor.symbol)
+                    .set_style(&style.cursor);
             }
 
             line_index += height;

--- a/src/tests/helpers/repo.rs
+++ b/src/tests/helpers/repo.rs
@@ -107,6 +107,11 @@ pub fn commit(dir: &Path, file_name: &str, contents: &str) {
         Ok(true) => format!("modify {}\n\nCommit body goes here\n", file_name),
         _ => format!("add {}\n\nCommit body goes here\n", file_name),
     };
+    commit_with_message(dir, &message, file_name, contents);
+}
+
+pub fn commit_with_message(dir: &Path, message: &str, file_name: &str, contents: &str) {
+    let path = dir.to_path_buf().join(file_name);
     fs::write(path, contents).expect("error writing to file");
     run(dir, &["git", "add", file_name]);
     run(dir, &["git", "commit", "-m", &message]);

--- a/src/tests/snapshots/gitu__tests__wrap__recent_commits.snap
+++ b/src/tests/snapshots/gitu__tests__wrap__recent_commits.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/mod.rs
+expression: ctx.redact_buffer()
+---
+  On branch main                                                                |
+                                                                                |
+  Recent commits                                                                |
+▌ ebac8f4 main This is a long line that is longer than 80 columns, to ensure    |
+▌↪that it definitely wraps on to the line below it                              |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: 556aa06940e8aa8

--- a/src/tests/snapshots/gitu__tests__wrap__recent_commits.snap
+++ b/src/tests/snapshots/gitu__tests__wrap__recent_commits.snap
@@ -6,7 +6,7 @@ expression: ctx.redact_buffer()
                                                                                 |
   Recent commits                                                                |
 ▌ ebac8f4 main This is a long line that is longer than 80 columns, to ensure    |
-▌↪that it definitely wraps on to the line below it                              |
+ ↪that it definitely wraps on to the line below it                              |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -22,4 +22,4 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
-styles_hash: 556aa06940e8aa8
+styles_hash: 76a85750ae78d878

--- a/src/tests/snapshots/gitu__tests__wrap__show.snap
+++ b/src/tests/snapshots/gitu__tests__wrap__show.snap
@@ -13,7 +13,7 @@ expression: ctx.redact_buffer()
   added      firstfile                                                          |
   @@ -0,0 +1 @@                                                                 |
 ▌ +This is a long line that is longer than 80 columns, to ensure that it        |
-▌↪definitely wraps on to the line below it                                      |
+ ↪definitely wraps on to the line below it                                      |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -22,4 +22,4 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
-styles_hash: 9ec7ed8a8eda4208
+styles_hash: eb4b8705c9e937b9

--- a/src/tests/snapshots/gitu__tests__wrap__show.snap
+++ b/src/tests/snapshots/gitu__tests__wrap__show.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/mod.rs
+expression: ctx.redact_buffer()
+---
+  commit cb440e69a12513df5754d1a8683ccfefcb89c1dd                               |
+  Author: Author Name <author@email.com>                                        |
+  Date:   Fri, 16 Feb 2024 11:11:00 +0100                                       |
+                                                                                |
+      add firstfile                                                             |
+                                                                                |
+      Commit body goes here                                                     |
+                                                                                |
+  added      firstfile                                                          |
+  @@ -0,0 +1 @@                                                                 |
+▌ +This is a long line that is longer than 80 columns, to ensure that it        |
+▌↪definitely wraps on to the line below it                                      |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: 9ec7ed8a8eda4208

--- a/src/tests/snapshots/gitu__tests__wrap__staged_changes.snap
+++ b/src/tests/snapshots/gitu__tests__wrap__staged_changes.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/mod.rs
+expression: ctx.redact_buffer()
+---
+  No branch                                                                     |
+                                                                                |
+  Staged changes (1)                                                            |
+  added      testfile                                                           |
+▌ @@ -0,0 +1 @@                                                                 |
+▌ +This is a long line that is longer than 80 columns, to ensure that it        |
+▌↪definitely wraps on to the line below it                                      |
+                                                                                |
+  Recent commits                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: 2fce71be5221797c

--- a/src/tests/snapshots/gitu__tests__wrap__staged_changes.snap
+++ b/src/tests/snapshots/gitu__tests__wrap__staged_changes.snap
@@ -8,7 +8,7 @@ expression: ctx.redact_buffer()
   added      testfile                                                           |
 ▌ @@ -0,0 +1 @@                                                                 |
 ▌ +This is a long line that is longer than 80 columns, to ensure that it        |
-▌↪definitely wraps on to the line below it                                      |
+ ↪definitely wraps on to the line below it                                      |
                                                                                 |
   Recent commits                                                                |
                                                                                 |
@@ -22,4 +22,4 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
-styles_hash: 2fce71be5221797c
+styles_hash: 5336fe13ab979e46

--- a/src/tests/snapshots/gitu__tests__wrap__unstaged_changes.snap
+++ b/src/tests/snapshots/gitu__tests__wrap__unstaged_changes.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/mod.rs
+expression: ctx.redact_buffer()
+---
+  On branch main                                                                |
+                                                                                |
+  Unstaged changes (1)                                                          |
+  modified   testfile                                                           |
+  @@ -1,2 +1 @@                                                                 |
+  -testing                                                                      |
+  -testtest                                                                     |
+▌ +This is a long line that is longer than 80 columns, to ensure that it        |
+▌↪definitely wraps on to the line below it                                      |
+                                                                                |
+  Recent commits                                                                |
+  f431046 main add testfile                                                     |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: 5ec29d64b309dd10

--- a/src/tests/snapshots/gitu__tests__wrap__unstaged_changes.snap
+++ b/src/tests/snapshots/gitu__tests__wrap__unstaged_changes.snap
@@ -10,7 +10,7 @@ expression: ctx.redact_buffer()
   -testing                                                                      |
   -testtest                                                                     |
 ▌ +This is a long line that is longer than 80 columns, to ensure that it        |
-▌↪definitely wraps on to the line below it                                      |
+ ↪definitely wraps on to the line below it                                      |
                                                                                 |
   Recent commits                                                                |
   f431046 main add testfile                                                     |
@@ -22,4 +22,4 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
-styles_hash: 5ec29d64b309dd10
+styles_hash: 6816abe8c2f3c32f


### PR DESCRIPTION
Previously long lines would be truncated, now instead they are wrapped and a wrap indicator displayed at the front of each line, after the first one.

The wrap indicator and collapse indicators are configurable.

<img width="658" alt="image" src="https://github.com/user-attachments/assets/08e64f0c-fee1-46cd-b51d-9fd304c3ecc9" />

Fixes #277 