### PR TITLE
feat: add delete option to branch menu

### DIFF
--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -101,6 +101,7 @@ help_menu.quit = ["q", "h", "?", "<esc>"]
 root.branch_menu = ["b"]
 branch_menu.checkout = ["b"]
 branch_menu.checkout_new_branch = ["c"]
+branch_menu.delete = ["K"]
 branch_menu.quit = ["q", "<esc>"]
 
 root.commit_menu = ["c"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,9 @@ pub enum Error {
     GetCurrentBranchUpstream(git2::Error),
     GetCurrentBranchUpstreamUtf8(Utf8Error),
     RemoteNameUtf8(Utf8Error),
+    CannotDeleteCurrentBranch,
+    BranchNameRequired,
+    IsBranchMerged(git2::Error),
     GetRemote(git2::Error),
     ReadGitConfig(git2::Error),
     ReadGitConfigUtf8(Utf8Error),
@@ -94,6 +97,11 @@ impl Display for Error {
                 f.write_str("Current branch upstream is not valid UTF-8")
             }
             Error::RemoteNameUtf8(_e) => f.write_str("Remote name is not valid UTF-8"),
+            Error::CannotDeleteCurrentBranch => f.write_str("Cannot delete current branch"),
+            Error::BranchNameRequired => f.write_str("Branch name required"),
+            Error::IsBranchMerged(e) => {
+                f.write_fmt(format_args!("Couldn't check if branch is merged: {}", e))
+            }
             Error::GetRemote(e) => f.write_fmt(format_args!("Couldn't get remote: {}", e)),
             Error::ReadGitConfig(e) => f.write_fmt(format_args!("Couldn't read git config: {}", e)),
             Error::ReadGitConfigUtf8(_e) => f.write_str("Git config is not valid UTF-8"),

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -7,7 +7,11 @@ use crate::{git, Res};
 use super::{Error, Utf8Error};
 
 pub(crate) fn get_upstream(repo: &Repository) -> Res<Option<Branch>> {
-    match git::get_current_branch(repo)?.upstream() {
+    get_branch_upstream(&git::get_current_branch(repo)?)
+}
+
+pub(crate) fn get_branch_upstream<'repo>(branch: &Branch<'repo>) -> Res<Option<Branch<'repo>>> {
+    match branch.upstream() {
         Ok(v) => Ok(Some(v)),
         Err(e) if e.class() == git2::ErrorClass::Config => Ok(None),
         Err(e) => Err(Error::GetCurrentBranchUpstream(e)),

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -50,7 +50,7 @@ impl PendingMenu {
             is_hidden: false,
             args: match menu {
                 Menu::Root => vec![],
-                Menu::Branch => ops::checkout::init_args(),
+                Menu::Branch => ops::branch::init_args(),
                 Menu::Commit => ops::commit::init_args(),
                 Menu::Fetch => ops::fetch::init_args(),
                 Menu::Help => vec![],

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::{items::TargetData, menu::Menu, state::State, term::Term, Res};
 use std::{fmt::Display, rc::Rc};
 
-pub(crate) mod checkout;
+pub(crate) mod branch;
 pub(crate) mod commit;
 pub(crate) mod copy_hash;
 pub(crate) mod discard;
@@ -42,6 +42,7 @@ pub(crate) trait OpTrait {
 pub(crate) enum Op {
     Checkout,
     CheckoutNewBranch,
+    Delete,
     Commit,
     CommitAmend,
     FetchAll,
@@ -120,8 +121,9 @@ impl Op {
             Op::HalfPageUp => Box::new(editor::HalfPageUp),
             Op::HalfPageDown => Box::new(editor::HalfPageDown),
 
-            Op::Checkout => Box::new(checkout::Checkout),
-            Op::CheckoutNewBranch => Box::new(checkout::CheckoutNewBranch),
+            Op::Checkout => Box::new(branch::Checkout),
+            Op::CheckoutNewBranch => Box::new(branch::CheckoutNewBranch),
+            Op::Delete => Box::new(branch::Delete),
             Op::Commit => Box::new(commit::Commit),
             Op::CommitAmend => Box::new(commit::CommitAmend),
             Op::FetchAll => Box::new(fetch::FetchAll),

--- a/src/tests/branch.rs
+++ b/src/tests/branch.rs
@@ -1,0 +1,51 @@
+use super::*;
+
+fn setup() -> TestContext {
+    let ctx = TestContext::setup_clone();
+    run(ctx.dir.path(), &["git", "checkout", "-b", "merged"]);
+    run(ctx.dir.path(), &["git", "checkout", "-b", "unmerged"]);
+    commit(ctx.dir.path(), "first commit", "");
+    run(ctx.dir.path(), &["git", "checkout", "main"]);
+    ctx
+}
+
+#[test]
+fn branch_menu() {
+    snapshot!(setup(), "Yjb");
+}
+
+#[test]
+fn switch_branch_selected() {
+    snapshot!(setup(), "Yjjbb<enter>");
+}
+
+#[test]
+fn switch_branch_input() {
+    snapshot!(setup(), "Ybbmerged<enter>");
+}
+
+#[test]
+fn checkout_new_branch() {
+    snapshot!(setup(), "bcnew<enter>");
+}
+
+#[test]
+fn delete_branch_selected() {
+    snapshot!(setup(), "YjjbK<enter>");
+}
+
+#[test]
+fn delete_branch_input() {
+    snapshot!(setup(), "bKmerged<enter>");
+}
+
+#[test]
+fn delete_branch_empty() {
+    snapshot!(setup(), "bK<enter>");
+}
+
+#[test]
+fn delete_unmerged_branch() {
+    // TODO: Remove <esc> once #368 is fixed
+    snapshot!(setup(), "bKunmerged<enter>n<esc>bKunmerged<enter>y");
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -17,6 +17,7 @@ use std::fs;
 #[macro_use]
 mod helpers;
 mod arg;
+mod branch;
 mod commit;
 mod discard;
 mod editor;
@@ -254,36 +255,6 @@ mod show_refs {
         let ctx = TestContext::setup_clone();
         run(ctx.dir.path(), &["git", "tag", "v1.0"]);
         snapshot!(ctx, "Yjjjjjjbb<enter>Y");
-    }
-}
-
-mod checkout {
-    use super::*;
-
-    #[test]
-    pub(crate) fn checkout_menu() {
-        let ctx = TestContext::setup_clone();
-        run(ctx.dir.path(), &["git", "branch", "other-branch"]);
-        snapshot!(ctx, "Yjb");
-    }
-
-    #[test]
-    pub(crate) fn switch_branch_selected() {
-        let ctx = TestContext::setup_clone();
-        run(ctx.dir.path(), &["git", "branch", "other-branch"]);
-        snapshot!(ctx, "Yjjbb<enter>");
-    }
-
-    #[test]
-    pub(crate) fn switch_branch_input() {
-        let ctx = TestContext::setup_clone();
-        run(ctx.dir.path(), &["git", "branch", "hi"]);
-        snapshot!(ctx, "Yjjbbhi<enter>");
-    }
-
-    #[test]
-    pub(crate) fn checkout_new_branch() {
-        snapshot!(TestContext::setup_clone(), "bcf<esc>cx<enter>");
     }
 }
 

--- a/src/tests/snapshots/gitu__tests__branch__branch_menu.snap
+++ b/src/tests/snapshots/gitu__tests__branch__branch_menu.snap
@@ -1,10 +1,11 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/branch.rs
 expression: ctx.redact_buffer()
 ---
  Branches                                                                       |
 ▌* main                                                                         |
-   other-branch                                                                 |
+   merged                                                                       |
+   unmerged                                                                     |
                                                                                 |
  Remote origin                                                                  |
    origin/HEAD                                                                  |
@@ -15,11 +16,10 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
-                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
 Branch                                                                          |
 b Checkout branch/revision                                                      |
 c Checkout new branch                                                           |
-d Delete branch                                                                 |
+K Delete branch                                                                 |
 q/<esc> Quit/Close                                                              |
-styles_hash: d05cb29e19813b7b
+styles_hash: c4812f62d5c8483d

--- a/src/tests/snapshots/gitu__tests__branch__checkout_new_branch.snap
+++ b/src/tests/snapshots/gitu__tests__branch__checkout_new_branch.snap
@@ -1,10 +1,13 @@
 ---
-source: src/tests/editor.rs
+source: src/tests/branch.rs
 expression: ctx.redact_buffer()
 ---
-▌No branch                                                                      |
+▌On branch new                                                                  |
                                                                                 |
  Recent commits                                                                 |
+ b66a0bf main merged new origin/main add initial-file                           |
+                                                                                |
+                                                                                |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -17,9 +20,6 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-Branch                                                                          |
-b Checkout branch/revision                                                      |
-c Checkout new branch                                                           |
-K Delete branch                                                                 |
-q/<esc> Quit/Close                                                              |
-styles_hash: 9ae8f56b30eeec76
+$ git checkout -b new                                                           |
+Switched to a new branch 'new'                                                  |
+styles_hash: c7925dfc1f0f00cd

--- a/src/tests/snapshots/gitu__tests__branch__delete_branch_empty.snap
+++ b/src/tests/snapshots/gitu__tests__branch__delete_branch_empty.snap
@@ -1,14 +1,12 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/branch.rs
 expression: ctx.redact_buffer()
 ---
- Branches                                                                       |
-▌* main                                                                         |
-   other-branch                                                                 |
+▌On branch main                                                                 |
+▌Your branch is up to date with 'origin/main'.                                  |
                                                                                 |
- Remote origin                                                                  |
-   origin/HEAD                                                                  |
-   origin/main                                                                  |
+ Recent commits                                                                 |
+ b66a0bf main merged origin/main add initial-file                               |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -20,6 +18,8 @@ expression: ctx.redact_buffer()
 Branch                                                                          |
 b Checkout branch/revision                                                      |
 c Checkout new branch                                                           |
-d Delete branch                                                                 |
+K Delete branch                                                                 |
 q/<esc> Quit/Close                                                              |
-styles_hash: d05cb29e19813b7b
+────────────────────────────────────────────────────────────────────────────────|
+! Branch name required                                                          |
+styles_hash: 343b1fffa75cf86c

--- a/src/tests/snapshots/gitu__tests__branch__delete_branch_forcefully.snap
+++ b/src/tests/snapshots/gitu__tests__branch__delete_branch_forcefully.snap
@@ -4,7 +4,6 @@ expression: ctx.redact_buffer()
 ---
  Branches                                                                       |
 ▌* main                                                                         |
-   other-branch                                                                 |
                                                                                 |
  Remote origin                                                                  |
    origin/HEAD                                                                  |
@@ -16,10 +15,11 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
-Branch                                                                          |
-b Checkout branch/revision                                                      |
-c Checkout new branch                                                           |
-d Delete branch                                                                 |
-q/<esc> Quit/Close                                                              |
-styles_hash: d05cb29e19813b7b
+$ git branch -d --force hi                                                      |
+Deleted branch hi (was b66a0bf).                                                |
+styles_hash: 5a3690c1fa3b2467

--- a/src/tests/snapshots/gitu__tests__branch__delete_branch_input.snap
+++ b/src/tests/snapshots/gitu__tests__branch__delete_branch_input.snap
@@ -1,10 +1,13 @@
 ---
-source: src/tests/editor.rs
+source: src/tests/branch.rs
 expression: ctx.redact_buffer()
 ---
-▌No branch                                                                      |
+▌On branch main                                                                 |
+▌Your branch is up to date with 'origin/main'.                                  |
                                                                                 |
  Recent commits                                                                 |
+ b66a0bf main origin/main add initial-file                                      |
+                                                                                |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -17,9 +20,6 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-Branch                                                                          |
-b Checkout branch/revision                                                      |
-c Checkout new branch                                                           |
-K Delete branch                                                                 |
-q/<esc> Quit/Close                                                              |
-styles_hash: 9ae8f56b30eeec76
+$ git branch -d merged                                                          |
+Deleted branch merged (was b66a0bf).                                            |
+styles_hash: fe4eba566a31096

--- a/src/tests/snapshots/gitu__tests__branch__delete_branch_selected.snap
+++ b/src/tests/snapshots/gitu__tests__branch__delete_branch_selected.snap
@@ -1,10 +1,10 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/branch.rs
 expression: ctx.redact_buffer()
 ---
  Branches                                                                       |
-▌* main                                                                         |
-   other-branch                                                                 |
+ * main                                                                         |
+▌  unmerged                                                                     |
                                                                                 |
  Remote origin                                                                  |
    origin/HEAD                                                                  |
@@ -16,10 +16,10 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
+                                                                                |
+                                                                                |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
-Branch                                                                          |
-b Checkout branch/revision                                                      |
-c Checkout new branch                                                           |
-d Delete branch                                                                 |
-q/<esc> Quit/Close                                                              |
-styles_hash: d05cb29e19813b7b
+$ git branch -d merged                                                          |
+Deleted branch merged (was b66a0bf).                                            |
+styles_hash: 653adde7e95e076f

--- a/src/tests/snapshots/gitu__tests__branch__delete_unmerged_branch.snap
+++ b/src/tests/snapshots/gitu__tests__branch__delete_unmerged_branch.snap
@@ -1,10 +1,13 @@
 ---
-source: src/tests/editor.rs
+source: src/tests/branch.rs
 expression: ctx.redact_buffer()
 ---
-▌No branch                                                                      |
+▌On branch main                                                                 |
+▌Your branch is up to date with 'origin/main'.                                  |
                                                                                 |
  Recent commits                                                                 |
+ b66a0bf main merged origin/main add initial-file                               |
+                                                                                |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -17,9 +20,6 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
 ────────────────────────────────────────────────────────────────────────────────|
-Branch                                                                          |
-b Checkout branch/revision                                                      |
-c Checkout new branch                                                           |
-K Delete branch                                                                 |
-q/<esc> Quit/Close                                                              |
-styles_hash: 9ae8f56b30eeec76
+$ git branch -d -f unmerged                                                     |
+Deleted branch unmerged (was c84f226).                                          |
+styles_hash: 7de97cab1939df6c

--- a/src/tests/snapshots/gitu__tests__branch__switch_branch_input.snap
+++ b/src/tests/snapshots/gitu__tests__branch__switch_branch_input.snap
@@ -1,10 +1,11 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/branch.rs
 expression: ctx.redact_buffer()
 ---
- Branches                                                                       |
-▌* main                                                                         |
-   other-branch                                                                 |
+▌Branches                                                                       |
+▌  main                                                                         |
+▌* merged                                                                       |
+▌  unmerged                                                                     |
                                                                                 |
  Remote origin                                                                  |
    origin/HEAD                                                                  |
@@ -16,10 +17,9 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
+                                                                                |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
-Branch                                                                          |
-b Checkout branch/revision                                                      |
-c Checkout new branch                                                           |
-d Delete branch                                                                 |
-q/<esc> Quit/Close                                                              |
-styles_hash: d05cb29e19813b7b
+$ git checkout merged                                                           |
+Switched to branch 'merged'                                                     |
+styles_hash: a0f9f5f991757004

--- a/src/tests/snapshots/gitu__tests__branch__switch_branch_selected.snap
+++ b/src/tests/snapshots/gitu__tests__branch__switch_branch_selected.snap
@@ -1,10 +1,11 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/branch.rs
 expression: ctx.redact_buffer()
 ---
  Branches                                                                       |
-▌* main                                                                         |
-   other-branch                                                                 |
+   main                                                                         |
+▌* merged                                                                       |
+   unmerged                                                                     |
                                                                                 |
  Remote origin                                                                  |
    origin/HEAD                                                                  |
@@ -16,10 +17,9 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
+                                                                                |
+                                                                                |
 ────────────────────────────────────────────────────────────────────────────────|
-Branch                                                                          |
-b Checkout branch/revision                                                      |
-c Checkout new branch                                                           |
-d Delete branch                                                                 |
-q/<esc> Quit/Close                                                              |
-styles_hash: d05cb29e19813b7b
+$ git checkout merged                                                           |
+Switched to branch 'merged'                                                     |
+styles_hash: 3e20cbd7891bb3eb


### PR DESCRIPTION
This PR adds support for deleting branches from the branch menu. If a branch hasn't been merged into upstream or HEAD, the operation must be confirmed (similar to how to `git branch -d ...` works).
