### PR TITLE
docs: fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -510,4 +510,3 @@ All notable changes to this project will be documented in this file.
 ### 🎨 Styling
 
 - Selection_line & selection_area now extend fully to left
-

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Here's a list of so-far supported features:
 - **Staging/Unstaging** _(file, hunk, line)_ 
 - **Showing** _(view commits / open EDITOR at line)_
 - **Branching** _(checkout, checkout new)_
-- **Commiting** _(commit, amend, fixup)_
+- **Committing** _(commit, amend, fixup)_
 - **Fetching**
 - **Logging** _(current, other)_
 - **Pulling / Pushing** _to/from configured upstream/pushDefault_

--- a/src/ops/log.rs
+++ b/src/ops/log.rs
@@ -21,7 +21,7 @@ pub(crate) fn init_args() -> Vec<Arg> {
             positive_number,
         ),
         Arg::new_arg("--grep", "Search messages", None, any_regex),
-        // Arg::new_str("-S", "Search occurences"), // TOOD: Implement search
+        // Arg::new_str("-S", "Search occurrences"), // TODO: Implement search
     ]
 }
 


### PR DESCRIPTION
Found via `typos --hidden --format brief`