### PR TITLE
fix(prompt): freeze when a command would fail after a prompt occurred

### DIFF
--- a/src/tests/branch.rs
+++ b/src/tests/branch.rs
@@ -46,6 +46,5 @@ fn delete_branch_empty() {
 
 #[test]
 fn delete_unmerged_branch() {
-    // TODO: Remove <esc> once #368 is fixed
-    snapshot!(setup(), "bKunmerged<enter>n<esc>bKunmerged<enter>y");
+    snapshot!(setup(), "bKunmerged<enter>nbKunmerged<enter>y");
 }

--- a/src/tests/editor.rs
+++ b/src/tests/editor.rs
@@ -57,11 +57,11 @@ fn move_next_then_parent_section() {
 }
 
 #[test]
-fn exit_from_prompt_shows_menu() {
+fn exit_from_prompt_exits_menu() {
     snapshot!(TestContext::setup_init(), "bb<esc>");
 }
 
 #[test]
 fn re_enter_prompt_from_menu() {
-    snapshot!(TestContext::setup_init(), "bb<esc>b");
+    snapshot!(TestContext::setup_init(), "bb<esc>bb");
 }

--- a/src/tests/snapshots/gitu__tests__editor__exit_from_prompt_exits_menu.snap
+++ b/src/tests/snapshots/gitu__tests__editor__exit_from_prompt_exits_menu.snap
@@ -16,10 +16,10 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
-────────────────────────────────────────────────────────────────────────────────|
-Branch                                                                          |
-b Checkout branch/revision                                                      |
-c Checkout new branch                                                           |
-K Delete branch                                                                 |
-q/<esc> Quit/Close                                                              |
-styles_hash: 9ae8f56b30eeec76
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: bc670d3bb6a7cf9a


### PR DESCRIPTION
Now a failed prompt will always close the menu, as well as removing the "hidden" state of it.
And a successful prompt will always unhide the menu.

closes: 368