### PR TITLE
fix: opening hunk in EDITOR used wrong line number

### DIFF
--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -74,16 +74,17 @@ impl Diff {
         format!("{}{}{}", file_header, hunk_header, modified_content)
     }
 
-    pub(crate) fn first_diff_line(&self, file_i: usize, hunk_i: usize) -> usize {
-        if let Some(change) = self.file_diffs[file_i].hunks[hunk_i]
-            .content
-            .changes
-            .first()
-        {
-            self.text[..change.old.start].lines().count()
-        } else {
-            0
+    pub(crate) fn file_line_of_first_diff(&self, file_i: usize, hunk_i: usize) -> usize {
+        let hunk = &self.file_diffs[file_i].hunks[hunk_i];
+        let line = hunk.header.new_line_start as usize;
+
+        let hunk_content = &self.text[hunk.content.range.clone()];
+        for (i, content_line) in hunk_content.lines().enumerate() {
+            if content_line.starts_with('+') || content_line.starts_with('-') {
+                return line + i;
+            }
         }
+        line
     }
 }
 

--- a/src/ops/show.rs
+++ b/src/ops/show.rs
@@ -19,7 +19,7 @@ impl OpTrait for Show {
                 hunk_i,
             }) => editor(
                 Path::new(&diff.text[diff.file_diffs[*file_i].header.new_file.clone()]),
-                Some(diff.first_diff_line(*file_i, *hunk_i) as u32),
+                Some(diff.file_line_of_first_diff(*file_i, *hunk_i) as u32),
             ),
             Some(TargetData::Stash { id: _, commit }) => goto_show_screen(commit.clone()),
             _ => None,


### PR DESCRIPTION
The file line number that was sent to $EDITOR was relative to the start of the diff text. We now use the parsed hunk header `new_line_start`, plus an offset to get to the first edited line in the hunk.

This behavior isn't always correct of course, but it's at least better for the common case of viewing a hunk in the diff of the working tree. When viewing a diff of an older commit, the hunk new_line_start doesn't necessarily refer to the correct line in the current code (and the relevant code might no longer exist). In this case, magit will open a buffer (revived from git) which reflects the code at the time of the commit. If you press enter while on a single changed line in the hunk, magit will show you the pre-edit or post-edit version of the code, depending on whether you're on a `-` or `+` diff line, which is pretty fancy.