### PR TITLE
feat: discard line by line (+ configure when to confirm discard)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,7 @@ pub struct GeneralConfig {
     pub always_show_help: BoolConfigEntry,
     pub confirm_quit: BoolConfigEntry,
     pub refresh_on_file_change: BoolConfigEntry,
+    pub confirm_discard: ConfirmDiscardOption,
     pub collapsed_sections: Vec<String>,
 }
 
@@ -30,6 +31,16 @@ pub struct GeneralConfig {
 pub struct BoolConfigEntry {
     #[serde(default)]
     pub enabled: bool,
+}
+
+#[derive(Default, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "lowercase")]
+pub enum ConfirmDiscardOption {
+    #[default]
+    Line,
+    Hunk,
+    File,
+    Never,
 }
 
 #[derive(Default, Debug, Deserialize)]

--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -10,6 +10,13 @@ confirm_quit.enabled = false
 collapsed_sections = []
 refresh_on_file_change.enabled = true
 
+# When to prompt for discard confirmation. Options:
+# "line"  - always prompt even for individual lines (default),
+# "hunk"  - prompt for files and hunks,
+# "file"  - only prompt when discarding whole files,
+# "never" - never prompt when discarding.
+confirm_discard = "line"
+
 [style]
 # fg / bg can be either of:
 # - a hex value: "#707070"

--- a/src/tests/discard.rs
+++ b/src/tests/discard.rs
@@ -71,6 +71,14 @@ pub(crate) fn discard_unstaged_hunk() {
 }
 
 #[test]
+pub(crate) fn discard_unstaged_line() {
+    let ctx = TestContext::setup_clone();
+    commit(ctx.dir.path(), "file-one", "FOO\nBAR\n");
+    fs::write(ctx.dir.child("file-one"), "blahonga\n").unwrap();
+    snapshot!(ctx, "jj<tab>j<ctrl+j>Ky<ctrl+j><ctrl+j>Ky");
+}
+
+#[test]
 pub(crate) fn discard_staged_file() {
     let ctx = TestContext::setup_clone();
     commit(ctx.dir.path(), "file-one", "FOO\nBAR\n");

--- a/src/tests/snapshots/gitu__tests__discard__discard_unstaged_line.snap
+++ b/src/tests/snapshots/gitu__tests__discard__discard_unstaged_line.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/discard.rs
+expression: ctx.redact_buffer()
+---
+ On branch main                                                                 |
+ Your branch is ahead of 'origin/main' by 1 commit.                             |
+                                                                                |
+ Unstaged changes (1)                                                           |
+ modified   file-one                                                            |
+ @@ -1,2 +1 @@                                                                  |
+  FOO                                                                           |
+▌-BAR                                                                           |
+                                                                                |
+ Recent commits                                                                 |
+ 4f3ed19 main add file-one                                                      |
+ b66a0bf origin/main add initial-file                                           |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+────────────────────────────────────────────────────────────────────────────────|
+$ git apply --reverse --recount                                                 |
+styles_hash: b29a924207accd5c


### PR DESCRIPTION
Adds discarding unstaged changes line by line.

By default you'd have to confirm each line that you unstage separately when unstaging several lines at once. As that might get a little tedious, I've added a config option `confirm_discard` that lets you choose the granularity of when to ask for confirmation:

```toml
confirm_discard = "line"  # asks on files/hunks/lines
confirm_discard = "hunk"  # asks on files/hunks
confirm_discard = "file"  # asks on files
confirm_discard = "never" # never asks, scary
```

The default is `"line"`, so you are asked to confirm no matter what you discard, which is backwards-compatible and probably the best for new users.

Curious what you think!