### PR TITLE
fix: report key bindings without "<>"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,6 +796,7 @@ dependencies = [
  "similar",
  "simple-logging",
  "strip-ansi-escapes",
+ "strum",
  "temp-dir",
  "termwiz",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,3 +63,4 @@ strip-ansi-escapes = "0.2.1"
 unicode-segmentation = "1.12.0"
 termwiz = "0.22.0"
 ratatui = { version = "0.29.0", features = ["termwiz", "serde", "underline-color"], default-features = false }
+strum = { version = "0.26.3", features = ["strum_macros"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,10 @@ pub enum Error {
     Termwiz(ratatui::termwiz::Error),
     GitDirUtf8(string::FromUtf8Error),
     Config(figment::Error),
+    Bindings {
+        bad_key_bindings: Vec<String>,
+        special_key_included: bool,
+    },
     FileWatcher(notify::Error),
     ReadRebaseStatusFile(io::Error),
     ReadBranchName(io::Error),
@@ -70,6 +74,19 @@ impl Display for Error {
             Error::Termwiz(e) => f.write_fmt(format_args!("Terminal error: {}", e)),
             Error::GitDirUtf8(_e) => f.write_str("Git directory not valid UTF-8"),
             Error::Config(e) => f.write_fmt(format_args!("Configuration error: {}", e)),
+            Error::Bindings {
+                bad_key_bindings,
+                special_key_included,
+            } => {
+                let mut error_string = String::from("Errors while parsing key bindings:");
+                for item in bad_key_bindings {
+                    error_string.push_str(&format!("\n{item}"));
+                }
+                if *special_key_included {
+                    error_string.push_str("\n\nSpecial keys like \"ctrl\" require key bindings to be surrounded, e.g. \"<ctrl+g>\"");
+                }
+                f.write_fmt(format_args!("{}", error_string))
+            }
             Error::FileWatcher(e) => f.write_fmt(format_args!("File watcher error: {}", e)),
             Error::ReadRebaseStatusFile(e) => {
                 f.write_fmt(format_args!("Couldn't read rebase status file: {}", e))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod term;
 mod tests;
 mod ui;
 
+use bindings::Bindings;
 use error::Error;
 use git2::Repository;
 use items::Item;
@@ -78,13 +79,13 @@ pub type Res<T> = Result<T, Error>;
 pub fn run(args: &cli::Args, term: &mut Term) -> Res<()> {
     let dir = find_git_dir()?;
     let repo = open_repo(&dir)?;
-    let config = Rc::new(config::init_config()?);
+    let config = config::init_config()?;
 
     let mut state = state::State::create(
         Rc::new(repo),
         term.size().map_err(Error::Term)?,
         args,
-        config.clone(),
+        Rc::new(config),
         true,
     )?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,10 @@ pub fn main() -> Res<()> {
     let mut terminal = Terminal::new(term::create_backend()?).map_err(Error::Term)?;
 
     if args.print {
-        return gitu::run(&args, &mut terminal);
+        if let Err(e) = gitu::run(&args, &mut terminal) {
+            eprintln!("{e}");
+            std::process::exit(1);
+        };
     }
 
     terminal.backend_mut().enter_alternate_screen()?;
@@ -31,7 +34,10 @@ pub fn main() -> Res<()> {
     terminal.hide_cursor().map_err(Error::Term)?;
     terminal.clear().map_err(Error::Term)?;
 
-    gitu::run(&args, &mut terminal)?;
+    if let Err(e) = gitu::run(&args, &mut terminal) {
+        eprintln!("{e}");
+        std::process::exit(1);
+    }
 
     Ok(())
 }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -8,34 +8,49 @@ use crate::ops;
 
 pub(crate) mod arg;
 
-#[derive(Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[derive(
+    Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Debug, Serialize, Deserialize, strum::AsRefStr,
+)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum Menu {
     #[serde(rename = "root")]
+    #[strum(serialize = "root")]
     Root,
     #[serde(rename = "branch_menu")]
+    #[strum(serialize = "branch_menu")]
     Branch,
     #[serde(rename = "commit_menu")]
+    #[strum(serialize = "commit_menu")]
     Commit,
     #[serde(rename = "fetch_menu")]
+    #[strum(serialize = "fetch_menu")]
     Fetch,
     #[serde(rename = "help_menu")]
+    #[strum(serialize = "help_menu")]
     Help,
     #[serde(rename = "log_menu")]
+    #[strum(serialize = "log_menu")]
     Log,
     #[serde(rename = "remote_menu")]
+    #[strum(serialize = "remote_menu")]
     Remote,
     #[serde(rename = "pull_menu")]
+    #[strum(serialize = "pull_menu")]
     Pull,
     #[serde(rename = "push_menu")]
+    #[strum(serialize = "push_menu")]
     Push,
     #[serde(rename = "rebase_menu")]
+    #[strum(serialize = "rebase_menu")]
     Rebase,
     #[serde(rename = "reset_menu")]
+    #[strum(serialize = "reset_menu")]
     Reset,
     #[serde(rename = "revert_menu")]
+    #[strum(serialize = "revert_menu")]
     Revert,
     #[serde(rename = "stash_menu")]
+    #[strum(serialize = "stash_menu")]
     Stash,
 }
 

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -38,8 +38,9 @@ pub(crate) trait OpTrait {
     fn display(&self, state: &State) -> String;
 }
 
-#[derive(Clone, PartialOrd, Ord, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[derive(Clone, PartialOrd, Ord, PartialEq, Eq, Debug, Serialize, Deserialize, strum::AsRefStr)]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub(crate) enum Op {
     AddRemote,
     Checkout,

--- a/src/state.rs
+++ b/src/state.rs
@@ -18,7 +18,6 @@ use termwiz::input::KeyCode;
 use termwiz::input::KeyEvent;
 use termwiz::input::Modifiers;
 
-use crate::bindings::Bindings;
 use crate::cli;
 use crate::cmd_log::CmdLog;
 use crate::cmd_log::CmdLogEntry;
@@ -42,7 +41,6 @@ use super::Res;
 pub(crate) struct State {
     pub repo: Rc<Repository>,
     pub config: Rc<Config>,
-    pub bindings: Bindings,
     pending_keys: Vec<(Modifiers, KeyCode)>,
     pub quit: bool,
     pub screens: Vec<Screen>,
@@ -80,7 +78,6 @@ impl State {
             )?],
         };
 
-        let bindings = Bindings::from(&config.bindings);
         let pending_menu = root_menu(&config).map(PendingMenu::init);
 
         let clipboard = Clipboard::new()
@@ -90,7 +87,6 @@ impl State {
         let mut state = Self {
             repo,
             config,
-            bindings,
             pending_keys: vec![],
             enable_async_cmds,
             quit: false,
@@ -219,6 +215,7 @@ impl State {
 
         self.pending_keys.push((key.modifiers, key.key));
         let matching_bindings = self
+            .config
             .bindings
             .match_bindings(&menu, &self.pending_keys)
             .collect::<Vec<_>>();

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -1,7 +1,5 @@
 use super::SizedWidget;
-use crate::{
-    bindings::Bindings, config::Config, items::Item, menu::PendingMenu, ops::Op, state::State,
-};
+use crate::{config::Config, items::Item, menu::PendingMenu, ops::Op, state::State};
 use itertools::Itertools;
 use ratatui::{
     buffer::Buffer,
@@ -17,17 +15,17 @@ pub(crate) struct MenuWidget<'a> {
 
 impl<'a> MenuWidget<'a> {
     pub fn new(
-        config: &Config,
-        bindings: &'a Bindings,
+        config: &'a Config,
         pending: &'a PendingMenu,
         item: &'a Item,
         state: &'a State,
     ) -> SizedWidget<Self> {
         let style = &config.style;
 
-        let arg_binds = bindings.arg_list(pending).collect::<Vec<_>>();
+        let arg_binds = config.bindings.arg_list(pending).collect::<Vec<_>>();
 
-        let non_target_binds = bindings
+        let non_target_binds = config
+            .bindings
             .list(&pending.menu)
             .filter(|keybind| !keybind.op.clone().implementation().is_target_op())
             .collect::<Vec<_>>();
@@ -77,7 +75,8 @@ impl<'a> MenuWidget<'a> {
 
         let mut right_column = vec![];
         if let Some(target_data) = &item.target_data {
-            let target_binds = bindings
+            let target_binds = config
+                .bindings
                 .list(&pending.menu)
                 .filter(|keybind| keybind.op.clone().implementation().is_target_op())
                 .filter(|keybind| {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -49,7 +49,6 @@ pub(crate) fn ui(frame: &mut Frame, state: &mut State) {
         } else {
             Some(menu::MenuWidget::new(
                 &state.config,
-                &state.bindings,
                 menu,
                 state.screens.last().unwrap().get_selected_item(),
                 state,


### PR DESCRIPTION
Fixes #256

This commit does a few things. Primarily, it validates that there are no key bindings like "ctrl+g" (these should be "<ctrl+g>", i.e. surrounded by angle brackets).

To ensure that the bindings are correct for the rest of the code, the `Config` struct has been split into something that `figment` recognises and another that's actually used.

Finally, if the whole program has an error, the `Display` representation is printed, not the `Debug` one; this makes the error messages easier for users to read.

It would be better to detect errors in the `nom` code, but I lack experience with this and get a headache every single time :)