### PR TITLE
perf: more efficiently keep track of changes between updates

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -196,6 +196,7 @@ pub(crate) fn init_config() -> Res<Config> {
         .merge(Toml::string(DEFAULT_CONFIG))
         .merge(Toml::file(config_path))
         .extract()
+        .map_err(Box::new)
         .map_err(Error::Config)?;
 
     Ok(config)
@@ -213,6 +214,7 @@ pub(crate) fn init_test_config() -> Res<Config> {
     let mut config: Config = Figment::new()
         .merge(Toml::string(DEFAULT_CONFIG))
         .extract()
+        .map_err(Box::new)
         .map_err(Error::Config)?;
 
     config.general.always_show_help.enabled = false;

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,7 +9,7 @@ pub enum Error {
     Term(io::Error),
     Termwiz(ratatui::termwiz::Error),
     GitDirUtf8(string::FromUtf8Error),
-    Config(figment::Error),
+    Config(Box<figment::Error>),
     FileWatcher(notify::Error),
     ReadRebaseStatusFile(io::Error),
     ReadBranchName(io::Error),

--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -24,13 +24,20 @@ impl Diff {
         mask_hunk_content(content, '+', '-')
     }
 
-    pub(crate) fn format_patch(&self, file_i: usize, hunk_i: usize) -> String {
-        let file_diff = &self.file_diffs[file_i];
+    pub(crate) fn format_hunk_patch(&self, file_i: usize, hunk_i: usize) -> String {
         format!(
             "{}{}",
-            &self.text[file_diff.header.range.clone()],
-            &self.text[file_diff.hunks[hunk_i].range.clone()]
+            self.file_diff_header(file_i),
+            self.hunk(file_i, hunk_i)
         )
+    }
+
+    pub(crate) fn file_diff_header(&self, file_i: usize) -> &str {
+        &self.text[self.file_diffs[file_i].header.range.clone()]
+    }
+
+    pub(crate) fn hunk(&self, file_i: usize, hunk_i: usize) -> &str {
+        &self.text[self.file_diffs[file_i].hunks[hunk_i].range.clone()]
     }
 
     pub(crate) fn format_line_patch(

--- a/src/items.rs
+++ b/src/items.rs
@@ -123,7 +123,7 @@ fn create_hunk_items(
 ) -> impl Iterator<Item = Item> {
     iter::once(Item {
         // TODO Don't do this
-        id: diff.format_patch(file_i, hunk_i).into(),
+        id: diff.format_hunk_patch(file_i, hunk_i).into(),
         display: Line::styled(
             diff.text[diff.file_diffs[file_i].hunks[hunk_i].header.range.clone()].to_string(),
             &config.style.hunk_header,

--- a/src/ops/discard.rs
+++ b/src/ops/discard.rs
@@ -133,7 +133,7 @@ fn discard_unstaged_patch(diff: Rc<Diff>, file_i: usize, hunk_i: usize) -> Actio
         cmd.args(["apply", "--reverse"]);
 
         state.close_menu();
-        state.run_cmd(term, &diff.format_patch(file_i, hunk_i).into_bytes(), cmd)
+        state.run_cmd(term, &diff.format_hunk_patch(file_i, hunk_i).into_bytes(), cmd)
     })
 }
 

--- a/src/ops/discard.rs
+++ b/src/ops/discard.rs
@@ -133,7 +133,11 @@ fn discard_unstaged_patch(diff: Rc<Diff>, file_i: usize, hunk_i: usize) -> Actio
         cmd.args(["apply", "--reverse"]);
 
         state.close_menu();
-        state.run_cmd(term, &diff.format_hunk_patch(file_i, hunk_i).into_bytes(), cmd)
+        state.run_cmd(
+            term,
+            &diff.format_hunk_patch(file_i, hunk_i).into_bytes(),
+            cmd,
+        )
     })
 }
 

--- a/src/ops/stage.rs
+++ b/src/ops/stage.rs
@@ -82,7 +82,7 @@ fn stage_patch(diff: Rc<Diff>, file_i: usize, hunk_i: usize) -> Action {
         cmd.args(["apply", "--cached"]);
 
         state.close_menu();
-        state.run_cmd(term, &diff.format_patch(file_i, hunk_i).into_bytes(), cmd)
+        state.run_cmd(term, &diff.format_hunk_patch(file_i, hunk_i).into_bytes(), cmd)
     })
 }
 

--- a/src/ops/stage.rs
+++ b/src/ops/stage.rs
@@ -82,7 +82,11 @@ fn stage_patch(diff: Rc<Diff>, file_i: usize, hunk_i: usize) -> Action {
         cmd.args(["apply", "--cached"]);
 
         state.close_menu();
-        state.run_cmd(term, &diff.format_hunk_patch(file_i, hunk_i).into_bytes(), cmd)
+        state.run_cmd(
+            term,
+            &diff.format_hunk_patch(file_i, hunk_i).into_bytes(),
+            cmd,
+        )
     })
 }
 

--- a/src/ops/unstage.rs
+++ b/src/ops/unstage.rs
@@ -14,7 +14,7 @@ impl OpTrait for Unstage {
                 diff,
                 file_i,
                 hunk_i,
-            }) => unstage_patch(diff.format_patch(file_i, hunk_i).into_bytes()),
+            }) => unstage_patch(diff.format_hunk_patch(file_i, hunk_i).into_bytes()),
             Some(TargetData::HunkLine {
                 diff,
                 file_i,

--- a/src/screen/mod.rs
+++ b/src/screen/mod.rs
@@ -1,9 +1,13 @@
 use ratatui::prelude::*;
 
-use crate::{config::Config, items::TargetData, Res};
+use crate::{
+    config::Config,
+    items::{hash, TargetData},
+    Res,
+};
 
 use super::Item;
-use std::{borrow::Cow, collections::HashSet, rc::Rc};
+use std::{collections::HashSet, rc::Rc};
 
 pub(crate) mod log;
 pub(crate) mod show;
@@ -27,7 +31,7 @@ pub(crate) struct Screen {
     refresh_items: Box<dyn Fn() -> Res<Vec<Item>>>,
     items: Vec<Item>,
     line_index: Vec<usize>,
-    collapsed: HashSet<Cow<'static, str>>,
+    collapsed: HashSet<u64>,
 }
 
 impl Screen {
@@ -41,7 +45,7 @@ impl Screen {
             .collapsed_sections
             .clone()
             .into_iter()
-            .map(Cow::Owned)
+            .map(hash)
             .collect();
 
         let mut screen = Self {
@@ -63,7 +67,7 @@ impl Screen {
             .iter()
             .filter(|item| item.default_collapsed)
             .for_each(|item| {
-                screen.collapsed.insert(item.id.clone());
+                screen.collapsed.insert(item.id);
             });
         screen.update_line_index();
 
@@ -196,7 +200,7 @@ impl Screen {
             if self.collapsed.contains(&selected.id) {
                 self.collapsed.remove(&selected.id);
             } else {
-                self.collapsed.insert(selected.id.clone());
+                self.collapsed.insert(selected.id);
             }
         }
 

--- a/src/screen/show.rs
+++ b/src/screen/show.rs
@@ -3,7 +3,7 @@ use std::{iter, rc::Rc};
 use crate::{
     config::Config,
     git,
-    items::{self, Item},
+    items::{self, hash, Item},
     Res,
 };
 use git2::Repository;
@@ -30,14 +30,14 @@ pub(crate) fn create(
             let details = Text::from(commit.details).lines;
 
             Ok(iter::once(Item {
-                id: format!("commit_section_{}", commit.hash).into(),
+                id: hash(["commit_section", &commit.hash]),
                 display: Line::styled(format!("commit {}", commit.hash), &style.section_header),
                 section: true,
                 depth: 0,
                 ..Default::default()
             })
             .chain(details.into_iter().map(|line| Item {
-                id: format!("commit_{}", commit.hash).into(),
+                id: hash(["commit", &commit.hash]),
                 display: line,
                 depth: 1,
                 unselectable: true,

--- a/src/screen/status.rs
+++ b/src/screen/status.rs
@@ -4,7 +4,7 @@ use crate::{
     error::Error,
     git::{self, diff::Diff},
     git2_opts,
-    items::{self, Item, TargetData},
+    items::{self, hash, Item, TargetData},
     Res,
 };
 use git2::Repository;
@@ -34,7 +34,7 @@ pub(crate) fn create(config: Rc<Config>, repo: Rc<Repository>, size: Size) -> Re
 
             let items = if let Some(rebase) = git::rebase_status(&repo)? {
                 vec![Item {
-                    id: "rebase_status".into(),
+                    id: hash("rebase_status"),
                     display: Line::styled(
                         format!("Rebasing {} onto {}", rebase.head_name, &rebase.onto),
                         &style.section_header,
@@ -44,7 +44,7 @@ pub(crate) fn create(config: Rc<Config>, repo: Rc<Repository>, size: Size) -> Re
                 .into_iter()
             } else if let Some(merge) = git::merge_status(&repo)? {
                 vec![Item {
-                    id: "merge_status".into(),
+                    id: hash("merge_status"),
                     display: Line::styled(
                         format!("Merging {}", &merge.head),
                         &style.section_header,
@@ -54,7 +54,7 @@ pub(crate) fn create(config: Rc<Config>, repo: Rc<Repository>, size: Size) -> Re
                 .into_iter()
             } else if let Some(revert) = git::revert_status(&repo)? {
                 vec![Item {
-                    id: "revert_status".into(),
+                    id: hash("revert_status"),
                     display: Line::styled(
                         format!("Reverting {}", &revert.head),
                         &style.section_header,
@@ -71,7 +71,7 @@ pub(crate) fn create(config: Rc<Config>, repo: Rc<Repository>, size: Size) -> Re
                 vec![
                     items::blank_line(),
                     Item {
-                        id: "untracked".into(),
+                        id: hash("untracked"),
                         display: Line::styled("Untracked files", &style.section_header),
                         section: true,
                         depth: 0,
@@ -115,7 +115,7 @@ fn items_list(config: &Config, files: Vec<PathBuf>) -> Vec<Item> {
     files
         .into_iter()
         .map(|path| Item {
-            id: path.to_string_lossy().to_string().into(),
+            id: hash(&path),
             display: Line::styled(path.to_string_lossy().to_string(), &style.file_header),
             depth: 1,
             target_data: Some(items::TargetData::File(path)),
@@ -128,7 +128,7 @@ fn branch_status_items(config: &Config, repo: &Repository) -> Res<Vec<Item>> {
     let style = &config.style;
     let Ok(head) = repo.head() else {
         return Ok(vec![Item {
-            id: "branch_status".into(),
+            id: hash("branch_status"),
             display: Line::styled("No branch", &style.section_header),
             section: true,
             depth: 0,
@@ -137,7 +137,7 @@ fn branch_status_items(config: &Config, repo: &Repository) -> Res<Vec<Item>> {
     };
 
     let mut items = vec![Item {
-        id: "branch_status".into(),
+        id: hash("branch_status"),
         display: Line::styled(
             format!("On branch {}", head.shorthand().unwrap()),
             &style.section_header,
@@ -158,7 +158,7 @@ fn branch_status_items(config: &Config, repo: &Repository) -> Res<Vec<Item>> {
 
     let Ok(upstream_id) = repo.refname_to_id(&upstream_name) else {
         items.push(Item {
-            id: "branch_status".into(),
+            id: hash("branch_status"),
             display: format!(
                 "Your branch is based on '{}', but the upstream is gone.",
                 upstream_shortname
@@ -176,7 +176,7 @@ fn branch_status_items(config: &Config, repo: &Repository) -> Res<Vec<Item>> {
         .map_err(Error::GitStatus)?;
 
     items.push(Item {
-        id: "branch_status".into(),
+        id: hash("branch_status"),
         display: if ahead == 0 && behind == 0 {
             Line::raw(format!("Your branch is up to date with '{}'.", upstream_shortname))
         } else if ahead > 0 && behind == 0 {
@@ -218,7 +218,7 @@ fn create_status_section_items<'a>(
                 ..Default::default()
             },
             Item {
-                id: snake_case_header.to_string().into(),
+                id: hash(snake_case_header),
                 display: Line::from(vec![
                     Span::styled(
                         capitalize(&snake_case_header.replace("_", " ")),
@@ -256,7 +256,7 @@ fn create_stash_list_section_items<'a>(
         vec![
             items::blank_line(),
             Item {
-                id: snake_case_header.to_string().into(),
+                id: hash(snake_case_header),
                 display: Line::styled(
                     capitalize(&snake_case_header.replace("_", " ")),
                     &style.section_header,
@@ -285,7 +285,7 @@ fn create_log_section_items<'a>(
             ..Default::default()
         },
         Item {
-            id: snake_case_header.to_string().into(),
+            id: hash(snake_case_header),
             display: Line::styled(
                 capitalize(&snake_case_header.replace("_", " ")),
                 &style.section_header,

--- a/src/term.rs
+++ b/src/term.rs
@@ -22,13 +22,13 @@ pub fn create_backend() -> Res<TermBackend> {
     )
     .map_err(Error::Termwiz)?;
 
-    Ok(TermBackend::Termwiz(
+    Ok(TermBackend::Termwiz(Box::new(
         TermwizBackend::with_buffered_terminal(buffered_terminal),
-    ))
+    )))
 }
 
 pub enum TermBackend {
-    Termwiz(TermwizBackend),
+    Termwiz(Box<TermwizBackend>),
     #[allow(dead_code)]
     Test {
         backend: TestBackend,


### PR DESCRIPTION
To keep item.id as a full-blown string with an exact copy of e.g. a hunk
was a total hack. This removes it and actually hashes content instead.

This is for now used to keep track of collapsed sections between updates.