### PR TITLE
fix: Shift modifier & uppercase key events would not work in certain terminals

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -187,8 +187,8 @@ impl App {
             InputEvent::Key(ref mut key) => {
                 // unify shift-prefixed key events between terminal emulators
                 // see: https://github.com/altsem/gitu/pull/394
-                if key.modifiers == Modifiers::SHIFT {
-                    if let KeyCode::Char(c) = key.key {
+                if let KeyCode::Char(c) = key.key {
+                    if key.modifiers == Modifiers::SHIFT {
                         key.key = KeyCode::Char(c.to_ascii_uppercase());
                         key.modifiers = Modifiers::NONE;
                     }

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -92,7 +92,7 @@ impl TextState<'_> {
             (KeyCode::Delete, _) | (KeyCode::Char('d'), Modifiers::CTRL) => self.delete(),
             (KeyCode::Char('k'), Modifiers::CTRL) => self.kill(),
             (KeyCode::Char('u'), Modifiers::CTRL) => self.truncate(),
-            (KeyCode::Char(c), Modifiers::NONE | Modifiers::SHIFT) => self.push(c),
+            (KeyCode::Char(c), Modifiers::NONE) => self.push(c),
             _ => {}
         }
     }


### PR DESCRIPTION
supersedes: https://github.com/altsem/gitu/pull/394