### PR TITLE
feat: Allow configuring recent commits and stash list limits

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,8 @@ pub struct GeneralConfig {
     pub refresh_on_file_change: BoolConfigEntry,
     pub confirm_discard: ConfirmDiscardOption,
     pub collapsed_sections: Vec<String>,
+    pub stash_list_limit: usize,
+    pub recent_commits_limit: usize,
 }
 
 #[derive(Default, Debug, Deserialize)]

--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -9,6 +9,8 @@ confirm_quit.enabled = false
 # collapsed_sections = ["untracked", "recent_commits", "branch_status"]
 collapsed_sections = []
 refresh_on_file_change.enabled = true
+stash_list_limit = 10
+recent_commits_limit = 10
 
 # When to prompt for discard confirmation. Options:
 # "line"  - always prompt even for individual lines (default),

--- a/src/screen/status.rs
+++ b/src/screen/status.rs
@@ -106,8 +106,14 @@ pub(crate) fn create(config: Rc<Config>, repo: Rc<Repository>, size: Size) -> Re
                 SectionID::StagedChanges,
                 &Rc::new(git::diff_staged(repo.as_ref())?),
             ))
-            .chain(create_stash_list_section_items(repo.as_ref()))
-            .chain(create_log_section_items(repo.as_ref()))
+            .chain(create_stash_list_section_items(
+                repo.as_ref(),
+                config.general.stash_list_limit,
+            ))
+            .chain(create_log_section_items(
+                repo.as_ref(),
+                config.general.recent_commits_limit,
+            ))
             .collect();
 
             Ok(items)
@@ -216,8 +222,11 @@ fn create_status_section_items<'a>(
     .chain(items::create_diff_items(diff, 1, true))
 }
 
-fn create_stash_list_section_items<'a>(repo: &Repository) -> impl Iterator<Item = Item> + 'a {
-    let stashes = items::stash_list(repo, 10).unwrap();
+fn create_stash_list_section_items<'a>(
+    repo: &Repository,
+    limit: usize,
+) -> impl Iterator<Item = Item> + 'a {
+    let stashes = items::stash_list(repo, limit).unwrap();
     if stashes.is_empty() {
         vec![]
     } else {
@@ -236,7 +245,10 @@ fn create_stash_list_section_items<'a>(repo: &Repository) -> impl Iterator<Item 
     .chain(stashes)
 }
 
-fn create_log_section_items<'a>(repo: &Repository) -> impl Iterator<Item = Item> + 'a {
+fn create_log_section_items<'a>(
+    repo: &Repository,
+    limit: usize,
+) -> impl Iterator<Item = Item> + 'a {
     [
         Item {
             depth: 0,
@@ -252,5 +264,5 @@ fn create_log_section_items<'a>(repo: &Repository) -> impl Iterator<Item = Item>
         },
     ]
     .into_iter()
-    .chain(items::log(repo, 10, None, None).unwrap())
+    .chain(items::log(repo, limit, None, None).unwrap())
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -101,6 +101,34 @@ fn collapsed_sections_config() {
 }
 
 #[test]
+fn stash_list_with_limit() {
+    let mut ctx = TestContext::setup_clone();
+    ctx.config().general.stash_list_limit = 2;
+
+    fs::write(ctx.dir.child("file1.txt"), "content").unwrap();
+    run(ctx.dir.path(), &["git", "add", "."]);
+    run(ctx.dir.path(), &["git", "stash", "save", "firststash"]);
+    fs::write(ctx.dir.child("file2.txt"), "content").unwrap();
+    run(ctx.dir.path(), &["git", "add", "."]);
+    run(ctx.dir.path(), &["git", "stash", "save", "secondstash"]);
+    fs::write(ctx.dir.child("file3.txt"), "content").unwrap();
+    run(ctx.dir.path(), &["git", "add", "."]);
+    run(ctx.dir.path(), &["git", "stash", "save", "thirdstash"]);
+
+    snapshot!(ctx, "");
+}
+
+#[test]
+fn recent_commits_with_limit() {
+    let mut ctx = TestContext::setup_clone();
+    ctx.config().general.recent_commits_limit = 2;
+    commit(ctx.dir.path(), "firstfile", "testing\ntesttest\n");
+    commit(ctx.dir.path(), "secondfile", "testing\ntesttest\n");
+    commit(ctx.dir.path(), "thirdfile", "testing\ntesttest\n");
+    snapshot!(ctx, "");
+}
+
+#[test]
 fn log() {
     let ctx = TestContext::setup_clone();
     commit(ctx.dir.path(), "firstfile", "testing\ntesttest\n");

--- a/src/tests/snapshots/gitu__tests__recent_commits_with_limit.snap
+++ b/src/tests/snapshots/gitu__tests__recent_commits_with_limit.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/mod.rs
+expression: ctx.redact_buffer()
+---
+▌On branch main                                                                 |
+▌Your branch is ahead of 'origin/main' by 3 commit(s).                          |
+                                                                                |
+ Recent commits                                                                 |
+ 421fbe4 main add thirdfile                                                     |
+ 0c2c6c3 add secondfile                                                         |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: 960194502264d5c0

--- a/src/tests/snapshots/gitu__tests__stash_list_with_limit.snap
+++ b/src/tests/snapshots/gitu__tests__stash_list_with_limit.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/mod.rs
+expression: ctx.redact_buffer()
+---
+▌On branch main                                                                 |
+▌Your branch is up to date with 'origin/main'.                                  |
+                                                                                |
+ Stashes                                                                        |
+ stash@0 On main: thirdstash                                                    |
+ stash@1 On main: secondstash                                                   |
+                                                                                |
+ Recent commits                                                                 |
+ b66a0bf main origin/main add initial-file                                      |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: be60d6ae62d5558f


### PR DESCRIPTION
The `general.recent_commits_limit` and `general.stash_list_limit` options can be used to configure each of these limits. They both default to 10.

Magit has `magit-log-section-commit-count` for the recent commits. However, I'm not sure Magit lets you configure the stash limit (directly), there doesn't seem to be an option and I have myself run into this annoyance when one has lots of stashes. 🫢