### PR TITLE
feat: Show diff on the stash detail screen

### DIFF
--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -177,6 +177,24 @@ pub(crate) fn show(repo: &Repository, reference: &str) -> Res<Diff> {
     })
 }
 
+pub(crate) fn stash_show(repo: &Repository, stash_ref: &str) -> Res<Diff> {
+    let text = String::from_utf8(
+        Command::new("git")
+            // TODO What if bare repo?
+            .current_dir(repo.workdir().expect("Bare repos unhandled"))
+            .args(["stash", "show", "-p", stash_ref])
+            .output()
+            .map_err(Error::GitShow)?
+            .stdout,
+    )
+    .map_err(Error::GitShowUtf8)?;
+
+    Ok(Diff {
+        file_diffs: gitu_diff::Parser::new(&text).parse_diff().unwrap(),
+        text,
+    })
+}
+
 pub(crate) fn show_summary(repo: &Repository, reference: &str) -> Res<Commit> {
     let object = &repo
         .revparse_single(reference)

--- a/src/item_data.rs
+++ b/src/item_data.rs
@@ -37,7 +37,7 @@ pub(crate) enum ItemData {
     },
     Stash {
         message: String,
-        commit: String,
+        stash_ref: String,
         id: usize,
     },
     Header(SectionHeader),

--- a/src/items.rs
+++ b/src/items.rs
@@ -265,12 +265,13 @@ pub(crate) fn stash_list(repo: &Repository, limit: usize) -> Res<Vec<Item>> {
         .enumerate()
         .map(|(i, stash)| -> Res<Item> {
             let stash_id = stash.id_new();
+            let stash_ref = format!("stash@{{{}}}", i);
             Ok(Item {
                 id: hash(stash_id),
                 depth: 1,
                 data: ItemData::Stash {
                     message: stash.message().unwrap_or("").to_string(),
-                    commit: stash_id.to_string(),
+                    stash_ref: stash_ref,
                     id: i,
                 },
                 ..Default::default()

--- a/src/ops/show.rs
+++ b/src/ops/show.rs
@@ -34,7 +34,7 @@ impl OpTrait for Show {
                 Path::new(&diff.text[diff.file_diffs[*file_i].header.new_file.clone()]),
                 Some(diff.file_line_of_first_diff(*file_i, *hunk_i) as u32),
             ),
-            ItemData::Stash { commit, .. } => goto_show_screen(commit.clone()),
+            ItemData::Stash { stash_ref, .. } => goto_show_stash_screen(stash_ref.clone()),
             _ => None,
         }
     }
@@ -58,6 +58,22 @@ fn goto_show_screen(r: String) -> Option<Action> {
                 r.clone(),
             )
             .expect("Couldn't create screen"),
+        );
+        Ok(())
+    }))
+}
+
+fn goto_show_stash_screen(stash_ref: String) -> Option<Action> {
+    Some(Rc::new(move |app, term| {
+        app.close_menu();
+        app.state.screens.push(
+            screen::show_stash::create(
+                Rc::clone(&app.state.config),
+                Rc::clone(&app.state.repo),
+                term.size().map_err(Error::Term)?,
+                stash_ref.clone(),
+            )
+            .expect("Couldn't create stash screen"),
         );
         Ok(())
     }))

--- a/src/screen/mod.rs
+++ b/src/screen/mod.rs
@@ -14,6 +14,7 @@ use std::{collections::HashSet, rc::Rc};
 pub(crate) mod log;
 pub(crate) mod show;
 pub(crate) mod show_refs;
+pub(crate) mod show_stash;
 pub(crate) mod status;
 
 const BOTTOM_CONTEXT_LINES: usize = 2;

--- a/src/screen/show_stash.rs
+++ b/src/screen/show_stash.rs
@@ -1,0 +1,48 @@
+use std::{iter, rc::Rc};
+
+use crate::{
+    config::Config,
+    git,
+    item_data::{ItemData, SectionHeader},
+    items::{self, hash, Item},
+    Res,
+};
+use git2::Repository;
+use ratatui::layout::Size;
+
+use super::Screen;
+
+pub(crate) fn create(
+    config: Rc<Config>,
+    repo: Rc<Repository>,
+    size: Size,
+    stash_ref: String,
+) -> Res<Screen> {
+    Screen::new(
+        Rc::clone(&config),
+        size,
+        Box::new(move || {
+            let commit = git::show_summary(repo.as_ref(), &stash_ref)?;
+            let show = git::stash_show(repo.as_ref(), &stash_ref)?;
+            let details = commit.details.lines();
+
+            Ok(iter::once(Item {
+                id: hash(["stash_section", &commit.hash]),
+                section: true,
+                depth: 0,
+                data: ItemData::Header(SectionHeader::Commit(commit.hash.clone())),
+                ..Default::default()
+            })
+            .chain(details.into_iter().map(|line| Item {
+                id: hash(["stash", &commit.hash]),
+                depth: 1,
+                unselectable: true,
+                data: ItemData::Raw(line.to_string()),
+                ..Default::default()
+            }))
+            .chain([items::blank_line()])
+            .chain(items::create_diff_items(&Rc::new(show), 0, false))
+            .collect())
+        }),
+    )
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -146,6 +146,19 @@ fn show() {
 }
 
 #[test]
+fn show_stash() {
+    let ctx = TestContext::setup_clone();
+
+    fs::write(ctx.dir.child("file1.txt"), "content").unwrap();
+    run(ctx.dir.path(), &["git", "add", "file1.txt"]);
+    // Unstaged changes to "file1.txt"
+    fs::write(ctx.dir.child("file1.txt"), "content\nmodified content").unwrap();
+    run(ctx.dir.path(), &["git", "stash", "save", "firststash"]);
+
+    snapshot!(ctx, "jj<enter>");
+}
+
+#[test]
 fn rebase_conflict() {
     let mut ctx = TestContext::setup_clone();
     commit(ctx.dir.path(), "new-file", "hello");

--- a/src/tests/snapshots/gitu__tests__show_stash.snap
+++ b/src/tests/snapshots/gitu__tests__show_stash.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/mod.rs
+expression: ctx.redact_buffer()
+---
+▌commit 0a076c73d486bf053bb41b602a7d0746a139c61c                                |
+▌Author: Author Name <author@email.com>                                         |
+▌Date:   Fri, 16 Feb 2024 11:11:00 +0100                                        |
+▌                                                                               |
+▌    On main: firststash                                                        |
+                                                                                |
+ unmerged   file1.txt                                                           |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: ba965d919318ab16

--- a/src/tests/snapshots/gitu__tests__show_stash.snap
+++ b/src/tests/snapshots/gitu__tests__show_stash.snap
@@ -2,19 +2,17 @@
 source: src/tests/mod.rs
 expression: ctx.redact_buffer()
 ---
-▌commit 0a076c73d486bf053bb41b602a7d0746a139c61c                                |
-▌Author: Author Name <author@email.com>                                         |
-▌Date:   Fri, 16 Feb 2024 11:11:00 +0100                                        |
-▌                                                                               |
-▌    On main: firststash                                                        |
+ commit 0a076c73d486bf053bb41b602a7d0746a139c61c                                |
+ Author: Author Name <author@email.com>                                         |
+ Date:   Fri, 16 Feb 2024 11:11:00 +0100                                        |
                                                                                 |
- unmerged   file1.txt                                                           |
+     On main: firststash                                                        |
                                                                                 |
-                                                                                |
-                                                                                |
-                                                                                |
-                                                                                |
-                                                                                |
+ added      file1.txt                                                           |
+▌@@ -0,0 +1,2 @@                                                                |
+▌+content                                                                       |
+▌+modified content                                                              |
+▌\ No newline at end of file                                                    |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -22,4 +20,6 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
-styles_hash: ba965d919318ab16
+                                                                                |
+                                                                                |
+styles_hash: 15f81f0e4dd370bc


### PR DESCRIPTION
Currently, the stash detail screen shows "unmerged" for all the files in the stash, which also means there is also no diff being shown for the stash.

It seems like the reason for "unmerged" is that the current implementation does `git show <stash_commit>` which ends up with `diff --cc` output, which the diff parser interprets as conflicts.

What I've changed here is to have a separate `show_stash` screen and to store the stash ref instead of the commit on the `ItemData::Stash` struct. The new screen runs `git stash show -p <stash_ref>` instead, which produces a diff that the diff parser is happier about.

I thought it was better to add something explicitly for showing stashes, rather than to try have a way to conditionally modify the diff parser, since it separates the concerns better at the cost of some conciseness in the code. More than happy to take suggestions.