### PR TITLE
feat: Simple mouse interactions

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -276,6 +276,15 @@ impl App {
             let click_y = (mouse.y as usize).saturating_sub(1);
             self.handle_op(Op::MoveToScreenLine(click_y), term)?;
             self.handle_op(Op::Show, term)?;
+        } else if mouse.mouse_buttons.contains(MouseButtons::VERT_WHEEL) {
+            let scroll_lines = self.state.config.general.mouse_scroll_lines;
+            if scroll_lines > 0 {
+                if mouse.mouse_buttons.contains(MouseButtons::WHEEL_POSITIVE) {
+                    self.screen_mut().scroll_up(scroll_lines);
+                } else {
+                    self.screen_mut().scroll_down(scroll_lines);
+                }
+            }
         }
 
         Ok(())

--- a/src/app.rs
+++ b/src/app.rs
@@ -264,13 +264,18 @@ impl App {
     fn handle_mouse_input(&mut self, term: &mut Term, mouse: &MouseEvent) -> Res<()> {
         if mouse.mouse_buttons == MouseButtons::LEFT {
             let click_y = (mouse.y as usize).saturating_sub(1);
-            let current_selected_item_id = self.screen().get_selected_item().id;
+            let old_selected_item_id = self.screen().get_selected_item().id;
             self.handle_op(Op::MoveToScreenLine(click_y), term)?;
+            let new_selected_item = self.screen().get_selected_item();
 
-            if current_selected_item_id == self.screen().get_selected_item().id {
+            if old_selected_item_id == new_selected_item.id {
                 // If the item clicked was already the current item, then try to
-                // toggle it.
-                self.handle_op(Op::ToggleSection, term)?;
+                // toggle it if it's a section or show it.
+                if new_selected_item.section {
+                    self.handle_op(Op::ToggleSection, term)?;
+                } else {
+                    self.handle_op(Op::Show, term)?;
+                }
             }
         } else if mouse.mouse_buttons == MouseButtons::RIGHT {
             let click_y = (mouse.y as usize).saturating_sub(1);

--- a/src/app.rs
+++ b/src/app.rs
@@ -187,8 +187,9 @@ impl App {
             }
             InputEvent::Mouse(ref mouse) => {
                 if self.state.config.general.mouse_support {
-                    self.handle_mouse_input(term, mouse)?;
-                    self.stage_redraw();
+                    if self.handle_mouse_input(term, mouse)? {
+                        self.stage_redraw();
+                    }
                 }
                 Ok(())
             }
@@ -278,7 +279,11 @@ impl App {
         Ok(())
     }
 
-    fn handle_mouse_input(&mut self, term: &mut Term, mouse: &MouseEvent) -> Res<()> {
+    fn handle_mouse_input(&mut self, term: &mut Term, mouse: &MouseEvent) -> Res<bool> {
+        if mouse.mouse_buttons == MouseButtons::NONE {
+            return Ok(false);
+        }
+
         if mouse.mouse_buttons == MouseButtons::LEFT {
             let click_y = (mouse.y as usize).saturating_sub(1);
             let old_selected_item_id = self.screen().get_selected_item().id;
@@ -309,7 +314,7 @@ impl App {
             }
         }
 
-        Ok(())
+        Ok(true)
     }
 
     pub(crate) fn handle_op(&mut self, op: Op, term: &mut Term) -> Res<()> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -494,6 +494,9 @@ impl App {
 
         // restore the raw mode
         term.backend_mut().enable_raw_mode()?;
+        if !self.state.config.general.mouse_support {
+            term.backend_mut().disable_mouse_reporting()?;
+        }
 
         // Prevents cursor flash when exiting editor
         term.hide_cursor().map_err(Error::Term)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,7 @@ pub struct GeneralConfig {
     pub stash_list_limit: usize,
     pub recent_commits_limit: usize,
     pub mouse_support: bool,
+    pub mouse_scroll_lines: usize,
 }
 
 #[derive(Default, Debug, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,7 @@ pub struct GeneralConfig {
     pub collapsed_sections: Vec<String>,
     pub stash_list_limit: usize,
     pub recent_commits_limit: usize,
+    pub mouse_support: bool,
 }
 
 #[derive(Default, Debug, Deserialize)]

--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -11,6 +11,7 @@ collapsed_sections = []
 refresh_on_file_change.enabled = true
 stash_list_limit = 10
 recent_commits_limit = 10
+mouse_support = false
 
 # When to prompt for discard confirmation. Options:
 # "line"  - always prompt even for individual lines (default),

--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -12,6 +12,7 @@ refresh_on_file_change.enabled = true
 stash_list_limit = 10
 recent_commits_limit = 10
 mouse_support = false
+mouse_scroll_lines = 3
 
 # When to prompt for discard confirmation. Options:
 # "line"  - always prompt even for individual lines (default),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,10 @@ pub fn run(args: &cli::Args, term: &mut Term) -> Res<()> {
     let repo = open_repo(&dir)?;
     let config = Rc::new(config::init_config(args.config.clone())?);
 
+    if !config.general.mouse_support {
+        term.backend_mut().disable_mouse_reporting()?;
+    }
+
     let mut app = app::App::create(
         Rc::new(repo),
         term.size().map_err(Error::Term)?,

--- a/src/ops/editor.rs
+++ b/src/ops/editor.rs
@@ -210,6 +210,22 @@ impl OpTrait for MoveUpLine {
     }
 }
 
+pub(crate) struct MoveToScreenLine(pub usize);
+impl OpTrait for MoveToScreenLine {
+    fn get_action(&self, _target: &ItemData) -> Option<Action> {
+        let screen_line = self.0;
+        Some(Rc::new(move |app, _term| {
+            app.close_menu();
+            app.screen_mut().move_cursor_to_screen_line(screen_line);
+            Ok(())
+        }))
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "Move to line".into()
+    }
+}
+
 pub(crate) struct MoveNextSection;
 impl OpTrait for MoveNextSection {
     fn get_action(&self, _target: &ItemData) -> Option<Action> {

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -117,6 +117,8 @@ pub(crate) enum Op {
     OpenMenu(Menu),
     #[serde(untagged)]
     ToggleArg(String),
+    #[serde(untagged)]
+    MoveToScreenLine(usize),
 }
 
 impl Op {
@@ -131,12 +133,12 @@ impl Op {
             Op::MoveUp => Box::new(editor::MoveUp),
             Op::MoveDownLine => Box::new(editor::MoveDownLine),
             Op::MoveUpLine => Box::new(editor::MoveUpLine),
+            Op::MoveToScreenLine(screen_line) => Box::new(editor::MoveToScreenLine(screen_line)),
             Op::MoveNextSection => Box::new(editor::MoveNextSection),
             Op::MovePrevSection => Box::new(editor::MovePrevSection),
             Op::MoveParentSection => Box::new(editor::MoveParentSection),
             Op::HalfPageUp => Box::new(editor::HalfPageUp),
             Op::HalfPageDown => Box::new(editor::HalfPageDown),
-
             Op::Checkout => Box::new(branch::Checkout),
             Op::CheckoutNewBranch => Box::new(branch::CheckoutNewBranch),
             Op::Delete => Box::new(branch::Delete),

--- a/src/screen/mod.rs
+++ b/src/screen/mod.rs
@@ -302,32 +302,23 @@ impl Screen {
             return;
         }
 
-        // Build a mapping from screen lines to cursor indices by recreating
-        // the same logic used in line_views.
-        let area_height = self.size.height as usize;
-        let scan_start = self.scroll.min(self.cursor);
-        let scan_end = (self.scroll + area_height).min(self.line_index.len());
-        let context_lines = self.scroll - scan_start;
-        let displayed_line_index: Vec<usize> = (scan_start..scan_end).skip(context_lines).collect();
-        if screen_line < displayed_line_index.len() {
-            let new_cursor = displayed_line_index[screen_line];
-            if self.cursor == new_cursor {
-                return;
-            }
+        let new_cursor = screen_line + self.scroll;
+        if new_cursor >= self.line_index.len() || self.cursor == new_cursor {
+            return;
+        }
 
-            let old_cursor = self.cursor;
-            self.cursor = new_cursor;
+        let old_cursor = self.cursor;
+        self.cursor = new_cursor;
 
-            let nav_mode = self.selected_item_nav_mode();
-            self.move_from_unselectable(nav_mode);
+        let nav_mode = self.selected_item_nav_mode();
+        self.move_from_unselectable(nav_mode);
 
-            if !self.nav_filter(self.cursor, nav_mode) {
-                // There was no selectable item, put the cursor back.
-                self.cursor = old_cursor;
-            } else {
-                // Use minimal scrolling to keep the cursor visible.
-                self.scroll_fit_start();
-            }
+        if !self.nav_filter(self.cursor, nav_mode) {
+            // There was no selectable item, put the cursor back.
+            self.cursor = old_cursor;
+        } else {
+            // Use minimal scrolling to keep the cursor visible.
+            self.scroll_fit_start();
         }
     }
 

--- a/src/screen/mod.rs
+++ b/src/screen/mod.rs
@@ -281,6 +281,40 @@ impl Screen {
         }
     }
 
+    pub(crate) fn move_cursor_to_screen_line(&mut self, screen_line: usize) {
+        if self.line_index.is_empty() {
+            return;
+        }
+
+        // Build a mapping from screen lines to cursor indices by recreating
+        // the same logic used in line_views.
+        let area_height = self.size.height as usize;
+        let scan_start = self.scroll.min(self.cursor);
+        let scan_end = (self.scroll + area_height).min(self.line_index.len());
+        let context_lines = self.scroll - scan_start;
+        let displayed_line_index: Vec<usize> = (scan_start..scan_end).skip(context_lines).collect();
+        if screen_line < displayed_line_index.len() {
+            let new_cursor = displayed_line_index[screen_line];
+            if self.cursor == new_cursor {
+                return;
+            }
+
+            let old_cursor = self.cursor;
+            self.cursor = new_cursor;
+
+            let nav_mode = self.selected_item_nav_mode();
+            self.move_from_unselectable(nav_mode);
+
+            if !self.nav_filter(self.cursor, nav_mode) {
+                // There was no selectable item, put the cursor back.
+                self.cursor = old_cursor;
+            } else {
+                // Use minimal scrolling to keep the cursor visible.
+                self.scroll_fit_start();
+            }
+        }
+    }
+
     fn is_collapsed(&self, item: &Item) -> bool {
         self.collapsed.contains(&item.id)
     }

--- a/src/screen/mod.rs
+++ b/src/screen/mod.rs
@@ -191,6 +191,22 @@ impl Screen {
         self.update_cursor(nav_mode);
     }
 
+    pub(crate) fn scroll_up(&mut self, lines: usize) {
+        self.scroll = self.scroll.saturating_sub(lines);
+        let nav_mode = self.selected_item_nav_mode();
+        self.update_cursor(nav_mode);
+    }
+
+    pub(crate) fn scroll_down(&mut self, lines: usize) {
+        let max_scroll = self
+            .line_index
+            .len()
+            .saturating_sub(self.size.height as usize);
+        self.scroll = (self.scroll + lines).min(max_scroll);
+        let nav_mode = self.selected_item_nav_mode();
+        self.update_cursor(nav_mode);
+    }
+
     pub(crate) fn toggle_section(&mut self) {
         let selected = &self.items[self.line_index[self.cursor]];
 

--- a/src/term.rs
+++ b/src/term.rs
@@ -138,6 +138,24 @@ impl TermBackend {
         }
     }
 
+    pub fn disable_mouse_reporting(&mut self) -> Res<()> {
+        match self {
+            TermBackend::Termwiz(_t) => {
+                #[cfg(unix)]
+                {
+                    use std::io::{stdout, Write};
+                    // Write the escapes directly to stdout, since Termwiz doesn't
+                    // have an API for mouse reporting.
+                    let mut stdout = stdout();
+                    stdout.write_all(b"\x1b[?1000l\x1b[?1002l\x1b[?1006l").ok();
+                    stdout.flush().ok();
+                }
+                Ok(())
+            }
+            TermBackend::Test { .. } => Ok(()),
+        }
+    }
+
     pub fn poll_input(&mut self, wait: Option<Duration>) -> Res<Option<InputEvent>> {
         match self {
             TermBackend::Termwiz(t) => t

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -482,3 +482,64 @@ fn mouse_show_item() {
     ctx.update(&mut app, vec![InputEvent::Mouse(mouse_event)]);
     insta::assert_snapshot!(ctx.redact_buffer());
 }
+
+#[test]
+fn mouse_wheel_scroll_up() {
+    let mut ctx = TestContext::setup_init();
+    ctx.config().general.mouse_support = true;
+
+    // Create many files to have something to scroll through
+    for i in 1..=30 {
+        let filename = format!("file{:02}", i);
+        let content = format!("line 1\nline 2\nline 3\nline 4\nline 5\n");
+        commit(ctx.dir.path(), &filename, &content);
+        fs::write(
+            ctx.dir.child(&filename),
+            format!("modified content {}\n", i),
+        )
+        .expect("error writing to file");
+    }
+
+    let mut app = ctx.init_app();
+
+    // Scroll down a bit to be able to scroll up.
+    ctx.update(&mut app, keys("<ctrl+d><ctrl+d>"));
+
+    let mouse_event = MouseEvent {
+        x: 0,
+        y: 10,
+        modifiers: Modifiers::NONE,
+        mouse_buttons: MouseButtons::VERT_WHEEL | MouseButtons::WHEEL_POSITIVE,
+    };
+    ctx.update(&mut app, vec![InputEvent::Mouse(mouse_event)]);
+    insta::assert_snapshot!(ctx.redact_buffer());
+}
+
+#[test]
+fn mouse_wheel_scroll_down() {
+    let mut ctx = TestContext::setup_init();
+    ctx.config().general.mouse_support = true;
+
+    // Create many files to have something to scroll through
+    for i in 1..=30 {
+        let filename = format!("file{:02}", i);
+        let content = format!("line 1\nline 2\nline 3\nline 4\nline 5\n");
+        commit(ctx.dir.path(), &filename, &content);
+        fs::write(
+            ctx.dir.child(&filename),
+            format!("modified content {}\n", i),
+        )
+        .expect("error writing to file");
+    }
+
+    let mut app = ctx.init_app();
+
+    let mouse_event = MouseEvent {
+        x: 0,
+        y: 10,
+        modifiers: Modifiers::NONE,
+        mouse_buttons: MouseButtons::VERT_WHEEL,
+    };
+    ctx.update(&mut app, vec![InputEvent::Mouse(mouse_event)]);
+    insta::assert_snapshot!(ctx.redact_buffer());
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -35,6 +35,7 @@ mod stash;
 mod unstage;
 
 use helpers::{clone_and_commit, commit, keys, run, TestContext};
+use termwiz::input::{InputEvent, Modifiers, MouseButtons, MouseEvent};
 
 #[test]
 fn no_repo() {
@@ -418,5 +419,66 @@ fn ext_diff() {
     );
     ctx.update(&mut app, keys("g"));
 
+    insta::assert_snapshot!(ctx.redact_buffer());
+}
+
+#[test]
+fn mouse_select_item() {
+    let mut ctx = TestContext::setup_init();
+    ctx.config().general.mouse_support = true;
+
+    commit(ctx.dir.path(), "testfile", "testing\ntesttest\n");
+
+    let mouse_event = MouseEvent {
+        x: 0,
+        y: 4,
+        modifiers: Modifiers::NONE,
+        mouse_buttons: MouseButtons::LEFT,
+    };
+    let mut app = ctx.init_app();
+    ctx.update(&mut app, vec![InputEvent::Mouse(mouse_event)]);
+    insta::assert_snapshot!(ctx.redact_buffer());
+}
+
+#[test]
+fn mouse_toggle_selected_item() {
+    let mut ctx = TestContext::setup_init();
+    ctx.config().general.mouse_support = true;
+
+    commit(ctx.dir.path(), "testfile", "testing\ntesttest\n");
+    fs::write(ctx.dir.child("testfile"), "test\nmoretest\n").expect("error writing to file");
+
+    let mouse_event = MouseEvent {
+        x: 0,
+        y: 4,
+        modifiers: Modifiers::NONE,
+        mouse_buttons: MouseButtons::LEFT,
+    };
+    let mut app = ctx.init_app();
+    ctx.update(
+        &mut app,
+        vec![
+            InputEvent::Mouse(mouse_event.clone()),
+            InputEvent::Mouse(mouse_event),
+        ],
+    );
+    insta::assert_snapshot!(ctx.redact_buffer());
+}
+
+#[test]
+fn mouse_show_item() {
+    let mut ctx = TestContext::setup_init();
+    ctx.config().general.mouse_support = true;
+
+    commit(ctx.dir.path(), "testfile", "testing\ntesttest\n");
+
+    let mouse_event = MouseEvent {
+        x: 0,
+        y: 4,
+        modifiers: Modifiers::NONE,
+        mouse_buttons: MouseButtons::RIGHT,
+    };
+    let mut app = ctx.init_app();
+    ctx.update(&mut app, vec![InputEvent::Mouse(mouse_event)]);
     insta::assert_snapshot!(ctx.redact_buffer());
 }

--- a/src/tests/snapshots/gitu__tests__mouse_select_item.snap
+++ b/src/tests/snapshots/gitu__tests__mouse_select_item.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/mod.rs
+expression: ctx.redact_buffer()
+---
+ On branch main                                                                 |
+                                                                                |
+ Recent commits                                                                 |
+▌f431046 main add testfile                                                      |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: 9d385ed9f86365bf

--- a/src/tests/snapshots/gitu__tests__mouse_show_item.snap
+++ b/src/tests/snapshots/gitu__tests__mouse_show_item.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/mod.rs
+expression: ctx.redact_buffer()
+---
+ commit f431046ef8cfa535f5ddf0a042cfdbcb1f7e64c8                                |
+ Author: Author Name <author@email.com>                                         |
+ Date:   Fri, 16 Feb 2024 11:11:00 +0100                                        |
+                                                                                |
+     add testfile                                                               |
+                                                                                |
+     Commit body goes here                                                      |
+                                                                                |
+ added      testfile                                                            |
+▌@@ -0,0 +1,2 @@                                                                |
+▌+testing                                                                       |
+▌+testtest                                                                      |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: 3185110292c06b5

--- a/src/tests/snapshots/gitu__tests__mouse_toggle_selected_item.snap
+++ b/src/tests/snapshots/gitu__tests__mouse_toggle_selected_item.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/mod.rs
+expression: ctx.redact_buffer()
+---
+ On branch main                                                                 |
+                                                                                |
+ Unstaged changes (1)                                                           |
+▌modified   testfile                                                            |
+▌@@ -1,2 +1,2 @@                                                                |
+▌-testing                                                                       |
+▌-testtest                                                                      |
+▌+test                                                                          |
+▌+moretest                                                                      |
+                                                                                |
+ Recent commits                                                                 |
+ f431046 main add testfile                                                      |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: 4df1e6312d2b7d53

--- a/src/tests/snapshots/gitu__tests__mouse_wheel_scroll_down.snap
+++ b/src/tests/snapshots/gitu__tests__mouse_wheel_scroll_down.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/mod.rs
+expression: ctx.redact_buffer()
+---
+ modified   file01…                                                             |
+ modified   file02…                                                             |
+ modified   file03…                                                             |
+ modified   file04…                                                             |
+ modified   file05…                                                             |
+ modified   file06…                                                             |
+ modified   file07…                                                             |
+ modified   file08…                                                             |
+ modified   file09…                                                             |
+ modified   file10…                                                             |
+▌modified   file11…                                                             |
+ modified   file12…                                                             |
+ modified   file13…                                                             |
+ modified   file14…                                                             |
+ modified   file15…                                                             |
+ modified   file16…                                                             |
+ modified   file17…                                                             |
+ modified   file18…                                                             |
+ modified   file19…                                                             |
+ modified   file20…                                                             |
+styles_hash: da4075784874982a

--- a/src/tests/snapshots/gitu__tests__mouse_wheel_scroll_up.snap
+++ b/src/tests/snapshots/gitu__tests__mouse_wheel_scroll_up.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/mod.rs
+expression: ctx.redact_buffer()
+---
+ modified   file15…                                                             |
+ modified   file16…                                                             |
+ modified   file17…                                                             |
+▌modified   file18…                                                             |
+ modified   file19…                                                             |
+ modified   file20…                                                             |
+ modified   file21…                                                             |
+ modified   file22…                                                             |
+ modified   file23…                                                             |
+ modified   file24…                                                             |
+ modified   file25…                                                             |
+ modified   file26…                                                             |
+ modified   file27…                                                             |
+ modified   file28…                                                             |
+ modified   file29…                                                             |
+ modified   file30…                                                             |
+                                                                                |
+ Recent commits                                                                 |
+ 45183e5 main add file30                                                        |
+ d823a8b add file29                                                             |
+styles_hash: f22bfab8ba35bcab


### PR DESCRIPTION
Magit has mouse support via emacs builtin mouse support, one particularly useful aspect of this is being able to jump around instantly instead of needing to navigate in a fashion like "next line, next line, … next line", such as when staging individual lines or moving to a particular commit/stash.

After using the mouse for a bit, I felt like perhaps there could be a few simple actions:

- Left clicking an item will move the cursor there
- Left clicking the item already at the cursor will toggle it if it's a section, or show it if not
- Right clicking an item will move the cursor there and immediately show it
- Scrolling the mouse wheel (or trackpad) scrolls the view up/down without moving the cursor position

I tried to use as much of what infrastructure was already there to support implementing this, but one thing I didn't do was make the mouse actions bindable. I looked at how this might be done, modifying the parser to accept `mouse1_click`, etc. seems very straightforward, but all of the parser functions return `KeyCode` and it seems like adjusting that might be it's own whole PR.

I added a config option `general.mouse_support` that defaults to `false` to preserve the existing behaviour, although it could be argued that since the mouse input is captured it would be more intuitive if it did something. This doesn't disable mouse reporting, but just ignores the mouse events.  I briefly looked at trying to disable mouse reporting in TermWiz, but my initial attempts didn't work. I think I would need to dig into the TermWiz source and CSI modes more to understand how to do this.

There's definitely some trailblazing in here, and some less-than-stellar code, so please feel free to suggest improvements.