### PR TITLE
fix: Ignore mouse clicks in empty regions

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -286,23 +286,27 @@ impl App {
 
         if mouse.mouse_buttons == MouseButtons::LEFT {
             let click_y = (mouse.y as usize).saturating_sub(1);
-            let old_selected_item_id = self.screen().get_selected_item().id;
-            self.handle_op(Op::MoveToScreenLine(click_y), term)?;
-            let new_selected_item = self.screen().get_selected_item();
+            if self.screen().is_valid_screen_line(click_y) {
+                let old_selected_item_id = self.screen().get_selected_item().id;
+                self.handle_op(Op::MoveToScreenLine(click_y), term)?;
+                let new_selected_item = self.screen().get_selected_item();
 
-            if old_selected_item_id == new_selected_item.id {
-                // If the item clicked was already the current item, then try to
-                // toggle it if it's a section or show it.
-                if new_selected_item.section {
-                    self.handle_op(Op::ToggleSection, term)?;
-                } else {
-                    self.handle_op(Op::Show, term)?;
+                if old_selected_item_id == new_selected_item.id {
+                    // If the item clicked was already the current item, then try to
+                    // toggle it if it's a section or show it.
+                    if new_selected_item.section {
+                        self.handle_op(Op::ToggleSection, term)?;
+                    } else {
+                        self.handle_op(Op::Show, term)?;
+                    }
                 }
             }
         } else if mouse.mouse_buttons == MouseButtons::RIGHT {
             let click_y = (mouse.y as usize).saturating_sub(1);
-            self.handle_op(Op::MoveToScreenLine(click_y), term)?;
-            self.handle_op(Op::Show, term)?;
+            if self.screen().is_valid_screen_line(click_y) {
+                self.handle_op(Op::MoveToScreenLine(click_y), term)?;
+                self.handle_op(Op::Show, term)?;
+            }
         } else if mouse.mouse_buttons.contains(MouseButtons::VERT_WHEEL) {
             let scroll_lines = self.state.config.general.mouse_scroll_lines;
             if scroll_lines > 0 {

--- a/src/screen/mod.rs
+++ b/src/screen/mod.rs
@@ -93,7 +93,7 @@ impl Screen {
         (0..self.line_index.len()).find(|&line_i| !self.at_line(line_i).unselectable)
     }
 
-    fn at_line(&mut self, line_i: usize) -> &Item {
+    fn at_line(&self, line_i: usize) -> &Item {
         &self.items[self.line_index[line_i]]
     }
 
@@ -140,7 +140,7 @@ impl Screen {
             .unwrap_or(self.cursor)
     }
 
-    fn nav_filter(&mut self, line_i: usize, nav_mode: NavMode) -> bool {
+    fn nav_filter(&self, line_i: usize, nav_mode: NavMode) -> bool {
         let item = self.at_line(line_i);
         match nav_mode {
             NavMode::Normal => {
@@ -328,6 +328,14 @@ impl Screen {
 
     pub(crate) fn get_selected_item(&self) -> &Item {
         &self.items[self.line_index[self.cursor]]
+    }
+
+    pub(crate) fn is_valid_screen_line(&self, screen_line: usize) -> bool {
+        let target_line_i = screen_line + self.scroll;
+        if self.line_index.is_empty() || target_line_i >= self.line_index.len() {
+            return false;
+        }
+        self.nav_filter(target_line_i, NavMode::IncludeHunkLines)
     }
 
     fn line_views(&self, area: Size) -> impl Iterator<Item = LineView<'_>> {

--- a/src/screen/status.rs
+++ b/src/screen/status.rs
@@ -204,11 +204,7 @@ fn create_status_section_items<'a>(
         };
 
         vec![
-            Item {
-                unselectable: true,
-                depth: 0,
-                ..Default::default()
-            },
+            items::blank_line(),
             Item {
                 id: hash(section),
                 section: true,

--- a/src/tests/helpers/ui.rs
+++ b/src/tests/helpers/ui.rs
@@ -11,7 +11,7 @@ use git2::Repository;
 use ratatui::{backend::TestBackend, layout::Size, Terminal};
 use std::{path::PathBuf, rc::Rc, time::Duration};
 use temp_dir::TempDir;
-use termwiz::input::{InputEvent, KeyEvent};
+use termwiz::input::{InputEvent, KeyEvent, Modifiers, MouseButtons, MouseEvent};
 
 use self::buffer::TestBuffer;
 
@@ -130,4 +130,13 @@ pub fn keys(input: &str) -> Vec<InputEvent> {
     keys.into_iter()
         .map(|(modifiers, key)| InputEvent::Key(KeyEvent { key, modifiers }))
         .collect()
+}
+
+pub fn mouse_event(x: u16, y: u16, mouse_buttons: MouseButtons) -> InputEvent {
+    InputEvent::Mouse(MouseEvent {
+        x,
+        y,
+        mouse_buttons,
+        modifiers: Modifiers::NONE,
+    })
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -435,6 +435,30 @@ fn mouse_select_item() {
 }
 
 #[test]
+fn mouse_select_hunk_line() {
+    let mut ctx = TestContext::setup_init();
+    ctx.config().general.mouse_support = true;
+
+    fs::write(ctx.dir.child("testfile"), "test\ntesttest\n").expect("error writing to file");
+    run(ctx.dir.path(), &["git", "add", "."]);
+    fs::write(ctx.dir.child("testfile"), "test\nmoretest\n").expect("error writing to file");
+
+    let mut app = ctx.init_app();
+    ctx.update(
+        &mut app,
+        vec![
+            // Select the file with an unstaged change.
+            mouse_event(0, 4, MouseButtons::LEFT),
+            // Expand the selected file.
+            mouse_event(0, 4, MouseButtons::LEFT),
+            // Select the hunk line.
+            mouse_event(0, 8, MouseButtons::LEFT),
+        ],
+    );
+    insta::assert_snapshot!(ctx.redact_buffer());
+}
+
+#[test]
 fn mouse_select_ignore_empty_lines() {
     let mut ctx = TestContext::setup_init();
     ctx.config().general.mouse_support = true;

--- a/src/tests/snapshots/gitu__tests__mouse_select_hunk_line.snap
+++ b/src/tests/snapshots/gitu__tests__mouse_select_hunk_line.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/mod.rs
+expression: ctx.redact_buffer()
+---
+ No branch                                                                      |
+                                                                                |
+ Unstaged changes (1)                                                           |
+ modified   testfile                                                            |
+ @@ -1,2 +1,2 @@                                                                |
+  test                                                                          |
+ -testtest                                                                      |
+▌+moretest                                                                      |
+                                                                                |
+ Staged changes (1)                                                             |
+ added      testfile…                                                           |
+                                                                                |
+ Recent commits                                                                 |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: 5265bcb857a5c4d8

--- a/src/tests/snapshots/gitu__tests__mouse_select_ignore_empty_lines.snap
+++ b/src/tests/snapshots/gitu__tests__mouse_select_ignore_empty_lines.snap
@@ -5,12 +5,7 @@ expression: ctx.redact_buffer()
  On branch main                                                                 |
                                                                                 |
  Unstaged changes (1)                                                           |
-▌modified   testfile                                                            |
-▌@@ -1,2 +1,2 @@                                                                |
-▌-testing                                                                       |
-▌-testtest                                                                      |
-▌+test                                                                          |
-▌+moretest                                                                      |
+▌modified   testfile…                                                           |
                                                                                 |
  Recent commits                                                                 |
  f431046 main add testfile                                                      |
@@ -22,4 +17,9 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
-styles_hash: 4df1e6312d2b7d53
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: b2ad77bb640fc2d4

--- a/src/tests/snapshots/gitu__tests__mouse_select_ignore_empty_lines.snap
+++ b/src/tests/snapshots/gitu__tests__mouse_select_ignore_empty_lines.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/mod.rs
+expression: ctx.redact_buffer()
+---
+ On branch main                                                                 |
+                                                                                |
+ Unstaged changes (1)                                                           |
+▌modified   testfile                                                            |
+▌@@ -1,2 +1,2 @@                                                                |
+▌-testing                                                                       |
+▌-testtest                                                                      |
+▌+test                                                                          |
+▌+moretest                                                                      |
+                                                                                |
+ Recent commits                                                                 |
+ f431046 main add testfile                                                      |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: 4df1e6312d2b7d53

--- a/src/tests/snapshots/gitu__tests__mouse_select_ignore_empty_region.snap
+++ b/src/tests/snapshots/gitu__tests__mouse_select_ignore_empty_region.snap
@@ -5,12 +5,7 @@ expression: ctx.redact_buffer()
  On branch main                                                                 |
                                                                                 |
  Unstaged changes (1)                                                           |
-▌modified   testfile                                                            |
-▌@@ -1,2 +1,2 @@                                                                |
-▌-testing                                                                       |
-▌-testtest                                                                      |
-▌+test                                                                          |
-▌+moretest                                                                      |
+▌modified   testfile…                                                           |
                                                                                 |
  Recent commits                                                                 |
  f431046 main add testfile                                                      |
@@ -22,4 +17,9 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
-styles_hash: 4df1e6312d2b7d53
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: b2ad77bb640fc2d4

--- a/src/tests/snapshots/gitu__tests__mouse_select_ignore_empty_region.snap
+++ b/src/tests/snapshots/gitu__tests__mouse_select_ignore_empty_region.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/mod.rs
+expression: ctx.redact_buffer()
+---
+ On branch main                                                                 |
+                                                                                |
+ Unstaged changes (1)                                                           |
+▌modified   testfile                                                            |
+▌@@ -1,2 +1,2 @@                                                                |
+▌-testing                                                                       |
+▌-testtest                                                                      |
+▌+test                                                                          |
+▌+moretest                                                                      |
+                                                                                |
+ Recent commits                                                                 |
+ f431046 main add testfile                                                      |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: 4df1e6312d2b7d53

--- a/src/tests/snapshots/gitu__tests__mouse_show_ignore_empty_lines.snap
+++ b/src/tests/snapshots/gitu__tests__mouse_show_ignore_empty_lines.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/mod.rs
+expression: ctx.redact_buffer()
+---
+ commit 0ceb2a2e799bdd15373901a2239705f3b04566b4                                |
+ Author: Author Name <author@email.com>                                         |
+ Date:   Fri, 16 Feb 2024 11:11:00 +0100                                        |
+                                                                                |
+     On main: firststash                                                        |
+                                                                                |
+ modified   testfile                                                            |
+▌@@ -1,2 +1,2 @@                                                                |
+▌-testing                                                                       |
+▌-testtest                                                                      |
+▌+test                                                                          |
+▌+moretest                                                                      |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: 19ccb2fc33bd4faf

--- a/src/tests/snapshots/gitu__tests__mouse_show_ignore_empty_lines.snap
+++ b/src/tests/snapshots/gitu__tests__mouse_show_ignore_empty_lines.snap
@@ -2,18 +2,13 @@
 source: src/tests/mod.rs
 expression: ctx.redact_buffer()
 ---
- commit 0ceb2a2e799bdd15373901a2239705f3b04566b4                                |
- Author: Author Name <author@email.com>                                         |
- Date:   Fri, 16 Feb 2024 11:11:00 +0100                                        |
+ On branch main                                                                 |
                                                                                 |
-     On main: firststash                                                        |
+ Stashes                                                                        |
+▌stash@0 On main: firststash                                                    |
                                                                                 |
- modified   testfile                                                            |
-▌@@ -1,2 +1,2 @@                                                                |
-▌-testing                                                                       |
-▌-testtest                                                                      |
-▌+test                                                                          |
-▌+moretest                                                                      |
+ Recent commits                                                                 |
+ f431046 main add testfile                                                      |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -22,4 +17,9 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
-styles_hash: 19ccb2fc33bd4faf
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: 601f39e098e07421

--- a/src/tests/snapshots/gitu__tests__mouse_show_ignore_empty_region.snap
+++ b/src/tests/snapshots/gitu__tests__mouse_show_ignore_empty_region.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/mod.rs
+expression: ctx.redact_buffer()
+---
+ commit 0ceb2a2e799bdd15373901a2239705f3b04566b4                                |
+ Author: Author Name <author@email.com>                                         |
+ Date:   Fri, 16 Feb 2024 11:11:00 +0100                                        |
+                                                                                |
+     On main: firststash                                                        |
+                                                                                |
+ modified   testfile                                                            |
+▌@@ -1,2 +1,2 @@                                                                |
+▌-testing                                                                       |
+▌-testtest                                                                      |
+▌+test                                                                          |
+▌+moretest                                                                      |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: 19ccb2fc33bd4faf

--- a/src/tests/snapshots/gitu__tests__mouse_show_ignore_empty_region.snap
+++ b/src/tests/snapshots/gitu__tests__mouse_show_ignore_empty_region.snap
@@ -2,18 +2,13 @@
 source: src/tests/mod.rs
 expression: ctx.redact_buffer()
 ---
- commit 0ceb2a2e799bdd15373901a2239705f3b04566b4                                |
- Author: Author Name <author@email.com>                                         |
- Date:   Fri, 16 Feb 2024 11:11:00 +0100                                        |
+ On branch main                                                                 |
                                                                                 |
-     On main: firststash                                                        |
+ Stashes                                                                        |
+▌stash@0 On main: firststash                                                    |
                                                                                 |
- modified   testfile                                                            |
-▌@@ -1,2 +1,2 @@                                                                |
-▌-testing                                                                       |
-▌-testtest                                                                      |
-▌+test                                                                          |
-▌+moretest                                                                      |
+ Recent commits                                                                 |
+ f431046 main add testfile                                                      |
                                                                                 |
                                                                                 |
                                                                                 |
@@ -22,4 +17,9 @@ expression: ctx.redact_buffer()
                                                                                 |
                                                                                 |
                                                                                 |
-styles_hash: 19ccb2fc33bd4faf
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: 601f39e098e07421


### PR DESCRIPTION
When pressing a mouse button on empty lines, or in the empty region at the bottom of the screen, the effect is the same as having clicked on the currently selected line. This is a bit of a jarring experience because it will often perform an unexpected action relative to where the mouse cursor actually is.

This PR changes mouse click events on invalid lines to be ignored, where invalid screens lines are:

- Lines that are unselectable
- Empty lines
- Lines beyond the bounds of the screen

I added tests for selecting hunk lines and other things that I found were missing test coverage.
