### PR TITLE
feat(file-watcher): start the watcher without blocking the main thread

### DIFF
--- a/src/file_watcher.rs
+++ b/src/file_watcher.rs
@@ -9,7 +9,6 @@ use std::{
 };
 
 pub struct FileWatcher {
-    _watcher: RecommendedWatcher,
     pending_updates: Arc<AtomicBool>,
 }
 
@@ -17,43 +16,53 @@ impl FileWatcher {
     pub fn new(repo_dir: &Path) -> Res<Self> {
         let pending_updates = Arc::new(AtomicBool::new(false));
         let pending_updates_w = pending_updates.clone();
+        let repo_dir_clone = repo_dir.to_path_buf();
 
-        let repo = open_repo(repo_dir)?;
-        let mut watcher = notify::recommended_watcher(move |res: Result<Event, notify::Error>| {
-            if let Ok(event) = res {
-                if !is_changed(&event) {
-                    return;
-                }
-
-                for path in event.paths {
-                    if !repo.status_should_ignore(&path).unwrap_or(false) {
-                        log::info!("File changed: {:?} ({:?})", path, event.kind);
-                        pending_updates_w.store(true, Ordering::Relaxed);
-                        break;
-                    }
-                }
+        std::thread::spawn(move || {
+            if let Err(e) = watch(&repo_dir_clone, pending_updates_w) {
+                log::error!("File watcher error: {:?}", e)
             }
-        })
-        .map_err(Error::FileWatcher)?;
+        });
 
-        let path_buf = repo_dir.to_owned();
-        watcher
-            .watch(&path_buf, RecursiveMode::Recursive)
-            .map_err(Error::FileWatcher)?;
-        log::info!(
-            "File watcher started (kind: {:?})",
-            RecommendedWatcher::kind()
-        );
-
-        Ok(Self {
-            _watcher: watcher,
-            pending_updates,
-        })
+        Ok(Self { pending_updates })
     }
 
     pub fn pending_updates(&self) -> bool {
         self.pending_updates.swap(false, Ordering::Relaxed)
     }
+}
+
+fn watch(repo_dir: &Path, pending_updates_w: Arc<AtomicBool>) -> Res<()> {
+    let repo = open_repo(repo_dir)?;
+    let mut watcher = notify::recommended_watcher(move |res: Result<Event, notify::Error>| {
+        if let Ok(event) = res {
+            if !is_changed(&event) {
+                return;
+            }
+
+            for path in event.paths {
+                if !repo.status_should_ignore(&path).unwrap_or(false) {
+                    log::info!("File changed: {:?} ({:?})", path, event.kind);
+                    pending_updates_w.store(true, Ordering::Relaxed);
+                    break;
+                }
+            }
+        }
+    })
+    .map_err(Error::FileWatcher)?;
+
+    let path_buf = repo_dir.to_owned();
+    watcher
+        .watch(&path_buf, RecursiveMode::Recursive)
+        .map_err(Error::FileWatcher)?;
+
+    log::info!(
+        "File watcher started (kind: {:?})",
+        RecommendedWatcher::kind()
+    );
+
+    std::mem::forget(watcher);
+    Ok(())
 }
 
 fn is_changed(event: &Event) -> bool {


### PR DESCRIPTION
@jonathanj put this back in a thread, I can't see how it wouldn't work on Mac. :thinking:
This time around the watcher doesn't move around threads.

previously reverted in: https://github.com/altsem/gitu/pull/360
related: https://github.com/altsem/gitu/issues/358, https://github.com/altsem/gitu/issues/374