### PR TITLE
feat(config): recognize "space" special character in key parser

### DIFF
--- a/src/key_parser.rs
+++ b/src/key_parser.rs
@@ -153,6 +153,7 @@ fn parse_special_key(input: &str) -> IResult<&str, KeyCode> {
             map(tag("end"), |_| KeyCode::End),
             map(tag("pageup"), |_| KeyCode::PageUp),
             map(tag("pagedown"), |_| KeyCode::PageDown),
+            map(tag("space"), |_| KeyCode::Char(' ')),
             map(tag("tab"), |_| KeyCode::Tab),
             map(tag("delete"), |_| KeyCode::Delete),
             map(tag("insert"), |_| KeyCode::Insert),
@@ -208,6 +209,10 @@ mod tests {
         assert_eq!(
             parse_key_combo("enter"),
             Ok(("", (KeyModifiers::NONE, vec![KeyCode::Enter])))
+        );
+        assert_eq!(
+            parse_key_combo("space"),
+            Ok(("", (KeyModifiers::NONE, vec![KeyCode::Char(' ')])))
         );
     }
 


### PR DESCRIPTION
This addresses a minor regression in #407 which rendered the following invalid:

    [bindings.root]
    stage = [" "]

Rather than removing the trimming of the key code string, this commit fixes the problem by recognizing "space" specially, similar to e.g. "tab". As a result, the above config can be achieved with:

    [bindings.root]
    stage = ["space"]

(Which is arguably clearer than the previous version too.)