### PR TITLE
fix: Keys double press on Windows (#385) (again)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -252,6 +252,10 @@ impl App {
     }
 
     fn handle_key_input(&mut self, term: &mut Term, key: event::KeyEvent) -> Res<()> {
+        if key.kind != event::KeyEventKind::Press {
+            return Ok(());
+        }
+
         let menu = match &self.state.pending_menu {
             None => Menu::Root,
             Some(menu) if menu.menu == Menu::Help => Menu::Root,


### PR DESCRIPTION
Tested on Windows and Linux. `make test` fails because of very sophisticated compilation error, maybe because of my environment.

@lbv points out how to fix it. I just verify that it works on my machine.


## Checklist
- [ ] The modified code has some test-coverage (where applicable).
- [ ] `make test` is passing (this is what CI runs).
- [x] New *unreleased* features/fixes/styling and performance improvements are documented via git: `feat:` / `fix:` / `style:` / `perf:`. Or e.g. `perf(highlighting):`.
      See [https://github.com/altsem/gitu/blob/master/docs/dev-tooling.md](https://github.com/altsem/gitu/blob/master/docs/dev-tooling.md)
