### PR TITLE
feat: Add support for git worktrees

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,32 +115,40 @@ pub fn run(config: Arc<Config>, args: &cli::Args, term: &mut Term) -> Res<()> {
 
 fn open_repo(dir: &Path) -> Res<Repository> {
     log::debug!("Opening repo");
-    let repo = open_repo_from_env()?;
+    let mut repo = Repository::open(dir).map_err(Error::OpenRepo)?;
+
+    if repo.is_worktree() {
+        repo = Repository::open(repo.commondir()).map_err(Error::OpenRepo)?;
+    }
+
     repo.set_workdir(dir, false).map_err(Error::OpenRepo)?;
     Ok(repo)
 }
 
 fn find_git_dir() -> Res<PathBuf> {
     log::debug!("Finding git dir");
-    let dir = PathBuf::from(
-        String::from_utf8(
-            Command::new("git")
-                .args(["rev-parse", "--show-toplevel"])
-                .output()
-                .map_err(Error::FindGitDir)?
-                .stdout,
-        )
-        .map_err(Error::GitDirUtf8)?
-        .trim_end(),
-    );
-    Ok(dir)
-}
 
-fn open_repo_from_env() -> Res<Repository> {
-    match Repository::open_from_env() {
-        Ok(repo) => Ok(repo),
-        Err(err) => Err(Error::OpenRepo(err)),
-    }
+    let output = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .map_err(Error::FindGitDir)?;
+
+    let status = output.status;
+
+    if !status.success() {
+        return Err(Error::CmdBadExit(
+            String::from_utf8(output.stderr).unwrap(),
+            status.code(),
+        ));
+    };
+
+    let dir = PathBuf::from(
+        String::from_utf8(output.stdout)
+            .map_err(Error::GitDirUtf8)?
+            .trim_end(),
+    );
+
+    Ok(dir)
 }
 
 fn keys_to_events(keys: &[(KeyModifiers, KeyCode)]) -> Vec<Event> {

--- a/src/tests/helpers/ui.rs
+++ b/src/tests/helpers/ui.rs
@@ -4,14 +4,15 @@ use crate::{
     config::{self, Config},
     error::Error,
     key_parser::parse_test_keys,
+    open_repo,
     term::{Term, TermBackend},
     tests::helpers::RepoTestContext,
 };
 use crossterm::event::{Event, KeyEvent, KeyModifiers, MouseButton, MouseEventKind};
-use git2::Repository;
 use ratatui::{Terminal, backend::TestBackend, layout::Size};
 use regex::Regex;
-use std::{path::PathBuf, rc::Rc, sync::Arc, time::Duration};
+use std::path::PathBuf;
+use std::{rc::Rc, sync::Arc, time::Duration};
 
 use self::buffer::TestBuffer;
 
@@ -69,7 +70,7 @@ impl TestContext {
 
     pub fn init_app_at_path(&mut self, path: PathBuf) -> App {
         let mut app = App::create(
-            Rc::new(Repository::open(path).unwrap()),
+            Rc::new(open_repo(&path).unwrap()),
             self.size,
             &Args::default(),
             Arc::clone(&self.config),

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -413,6 +413,42 @@ fn inside_submodule() {
 }
 
 #[test]
+fn inside_shallow() {
+    let mut ctx = setup_clone!();
+    let url = Url::from_file_path(&ctx.remote_dir).unwrap().to_string();
+    run(&ctx.dir, &["git", "clone", "--depth=1", &url, "shallow"]);
+
+    let _app = ctx.init_app_at_path(ctx.dir.join("shallow"));
+    insta::assert_snapshot!(ctx.redact_buffer());
+}
+
+#[test]
+fn inside_worktree() {
+    let mut ctx = setup_clone!();
+    run(&ctx.dir, &["git", "checkout", "-b", "new-branch"]);
+    run(&ctx.dir, &["git", "worktree", "add", "main"]);
+
+    let _app = ctx.init_app_at_path(ctx.dir.join("main"));
+    insta::assert_snapshot!(ctx.redact_buffer());
+}
+
+#[test]
+fn inside_shallow_worktree() {
+    let mut ctx = setup_clone!();
+    clone_and_commit(&ctx.remote_dir, "new-file", "hello");
+
+    let url = Url::from_file_path(&ctx.remote_dir).unwrap().to_string();
+    run(&ctx.dir, &["git", "clone", "--depth=1", &url, "shallow"]);
+
+    let shallow_dir = ctx.dir.join("shallow");
+    run(&shallow_dir, &["git", "checkout", "-b", "new-branch"]);
+    run(&shallow_dir, &["git", "worktree", "add", "main"]);
+
+    let _app = ctx.init_app_at_path(shallow_dir.join("main"));
+    insta::assert_snapshot!(ctx.redact_buffer());
+}
+
+#[test]
 fn syntax_highlighted() {
     let ctx = setup_clone!();
     commit(

--- a/src/tests/snapshots/gitu__tests__inside_shallow.snap
+++ b/src/tests/snapshots/gitu__tests__inside_shallow.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/mod.rs
+expression: ctx.redact_buffer()
+---
+▌On branch main                                                                 |
+▌Your branch is up to date with 'origin/main'.                                  |
+                                                                                |
+ Recent commits                                                                 |
+ b66a0bf main origin/main add initial-file                                      |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: f47a6512af0aca26

--- a/src/tests/snapshots/gitu__tests__inside_shallow_worktree.snap
+++ b/src/tests/snapshots/gitu__tests__inside_shallow_worktree.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/mod.rs
+expression: ctx.redact_buffer()
+---
+▌On branch main                                                                 |
+▌Your branch is up to date with 'origin/main'.                                  |
+                                                                                |
+ Recent commits                                                                 |
+ 46c81ca main new-branch origin/main add new-file                               |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: 4d5a9a1a08dc1d60

--- a/src/tests/snapshots/gitu__tests__inside_worktree.snap
+++ b/src/tests/snapshots/gitu__tests__inside_worktree.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/mod.rs
+expression: ctx.redact_buffer()
+---
+▌On branch main                                                                 |
+▌Your branch is up to date with 'origin/main'.                                  |
+                                                                                |
+ Recent commits                                                                 |
+ b66a0bf main new-branch origin/main add initial-file                           |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: 4d5a9a1a08dc1d60


### PR DESCRIPTION
I experimented a bit with worktrees and bare repositories and found a bug where ~~Gitu isn’t able to fetch the history for a worktree created in a bare repository. This PR fixes the issue and makes the tests use the same function to open repositories as regular Gitu.~~

**Update:** The issue is actually in libgit2; shallow grafts are not set correctly for "shallow" worktrees.

Error:

```
-old snapshot
+new results
────────────┬────────────────────────────────────────────────────────────────────────────────────────────────
    1     1 │ ▌On branch main                                                                 |
    2     2 │ ▌Your branch is up to date with 'origin/main'.                                  |
    3     3 │                                                                                 |
    4     4 │  Recent commits                                                                 |
    5       │- Couldn't read log: object not found - no match for id (b66a0bf82020d6a386e94d0…|
          5 │+ 46c81ca main new-branch origin/main add new-file                               |
    6     6 │                                                                                 |
    7     7 │                                                                                 |
    8     8 │                                                                                 |
    9     9 │                                                                                 |
┈┈┈┈┈┈┈┈┈┈┈┈┼┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
   17    17 │                                                                                 |
   18    18 │                                                                                 |
   19    19 │                                                                                 |
   20    20 │                                                                                 |
   21       │-styles_hash: 2b21a6aa63fe13b3
         21 │+styles_hash: 4d5a9a1a08dc1d60
────────────┴────────────────────────────────────────────────────────────────────────────────────────────────
```

## Checklist

- [x] The modified code has some test-coverage (where applicable).
- [x] `make test` is passing (this is what CI runs).
- [x] New *unreleased* features/fixes/styling and performance improvements are documented via git: `feat:` / `fix:` / `style:` / `perf:`. Or e.g. `perf(highlighting):`.
  See [https://github.com/altsem/gitu/blob/master/docs/dev-tooling.md](https://github.com/altsem/gitu/blob/master/docs/dev-tooling.md)
