### PR TITLE
fix: show works with kakoune

### DIFF
--- a/src/ops/show.rs
+++ b/src/ops/show.rs
@@ -135,6 +135,7 @@ fn line_args(file: &str, maybe_line: Option<u32>, lower: String) -> Vec<String> 
             || lower.ends_with("nano")
             || lower.ends_with("micro")
             || lower.ends_with("nvr")
+            || lower.ends_with("kak")
         {
             vec![format!("+{line}"), file.to_string()]
         } else {


### PR DESCRIPTION
[kakoune](https://github.com/mawww/kakoune) uses the `kak +<line> <file>` syntax to open a file to a line. When running `kak <file>:<line>`, it thinks that you are trying to open a file named `<file>:<line>`. Since this file almost certainly does not exist, it opens an empty buffer. This commit just adds kakoune to the hardcoded list of editors with the `+<line>` syntax.


## Checklist
- [x] The modified code has some test-coverage (where applicable).
    - Test coverage did not seem applicable here, there are not currently tests for each editor in the modified conditional check, just tests that ensure lowercasing and argument parsing work correctly, which are unchanged.
- [x] `make test` is passing (this is what CI runs).
    - It's actually not all passing on my machine, `cargo clippy -- -Dwarnings` is failing due to something in `src/picker.rs` that is unrelated to this change. This failure is not introduced by this change, it is present in the current `master` (a887673). Seems like it is passing on CI though.
- [x] New *unreleased* features/fixes/styling and performance improvements are documented via git: `feat:` / `fix:` / `style:` / `perf:`. Or e.g. `perf(highlighting):`.
      See [https://github.com/altsem/gitu/blob/master/docs/dev-tooling.md](https://github.com/altsem/gitu/blob/master/docs/dev-tooling.md)

