### PR TITLE
wip: blame

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -79,6 +79,7 @@ impl App {
                     Rc::clone(&repo),
                     size,
                     reference.clone(),
+                    None,
                 )?]
             }
             None => vec![screen::status::create(

--- a/src/config.rs
+++ b/src/config.rs
@@ -112,6 +112,17 @@ pub struct StyleConfig {
     pub branch: StyleConfigEntry,
     pub remote: StyleConfigEntry,
     pub tag: StyleConfigEntry,
+
+    #[serde(default)]
+    pub blame: BlameStyleConfig,
+}
+
+#[derive(Default, Debug, Deserialize)]
+pub struct BlameStyleConfig {
+    #[serde(default)]
+    pub line_num: StyleConfigEntry,
+    #[serde(default)]
+    pub code_line: StyleConfigEntry,
 }
 
 #[derive(Default, Debug, Deserialize)]

--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -100,6 +100,9 @@ branch = { fg = "green" }
 remote = { fg = "red" }
 tag = { fg = "yellow" }
 
+blame.line_num = { mods = "DIM" }
+blame.code_line = { mods = "DIM" }
+
 [bindings]
 root.quit = ["q", "esc"]
 root.refresh = ["g"]
@@ -121,6 +124,7 @@ root.unstage = ["u"]
 root.apply = ["a"]
 root.reverse = ["v"]
 root.copy_hash = ["y"]
+root.blame = ["B"]
 
 picker.next = ["down", "ctrl+n", "tab"]
 picker.previous = ["up", "ctrl+p", "backtab"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -58,6 +58,7 @@ pub enum Error {
     GetBranchName(git2::Error),
     BaseCommitOid,
     UpstreamCommitOid,
+    GitBlame(io::Error),
 }
 
 impl std::error::Error for Error {}
@@ -164,6 +165,7 @@ impl Display for Error {
             Error::UpstreamCommitOid => {
                 f.write_str("Could not resolve OID of upstream branch commit")
             }
+            Error::GitBlame(e) => f.write_fmt(format_args!("Git blame error: {e}")),
         }
     }
 }

--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -6,6 +6,7 @@ pub(crate) struct Diff {
     pub text: String,
     pub diff_type: DiffType,
     pub file_diffs: Vec<FileDiff>,
+    pub commit: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -102,6 +103,36 @@ impl Diff {
             .collect::<String>();
 
         format!("{file_header}{hunk_header}{modified_content}")
+    }
+
+    pub(crate) fn hunk_first_changed_line_num(&self, file_i: usize, hunk_i: usize) -> u32 {
+        let new_line_start = self.file_diffs[file_i].hunks[hunk_i].header.new_line_start;
+        let mut new_line = new_line_start;
+        for line in self.hunk_content(file_i, hunk_i).lines() {
+            if line.starts_with('+') {
+                return new_line;
+            }
+            if !line.starts_with('-') {
+                new_line += 1;
+            }
+        }
+        new_line_start
+    }
+
+    pub(crate) fn hunk_line_new_file_num(
+        &self,
+        file_i: usize,
+        hunk_i: usize,
+        line_i: usize,
+    ) -> u32 {
+        let hunk = &self.file_diffs[file_i].hunks[hunk_i];
+        let non_minus_before = self
+            .hunk_content(file_i, hunk_i)
+            .lines()
+            .take(line_i)
+            .filter(|l| l.starts_with(' ') || l.starts_with('+'))
+            .count() as u32;
+        hunk.header.new_line_start + non_minus_before
     }
 
     pub(crate) fn file_line_of_first_diff(&self, file_i: usize, hunk_i: usize) -> usize {

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -168,6 +168,7 @@ pub(crate) fn diff_unstaged(repo: &Repository) -> Res<Diff> {
         file_diffs: gitu_diff::Parser::new(&text).parse_diff().unwrap(),
         diff_type: DiffType::WorkdirToIndex,
         text,
+        commit: None,
     })
 }
 
@@ -186,6 +187,7 @@ pub(crate) fn diff_staged(repo: &Repository) -> Res<Diff> {
         file_diffs: gitu_diff::Parser::new(&text).parse_diff().unwrap(),
         diff_type: DiffType::IndexToTree,
         text,
+        commit: None,
     })
 }
 
@@ -218,6 +220,7 @@ pub(crate) fn show(repo: &Repository, reference: &str) -> Res<Diff> {
         file_diffs: gitu_diff::Parser::new(&text).parse_diff().unwrap(),
         diff_type: DiffType::TreeToTree,
         text,
+        commit: Some(reference.to_string()),
     })
 }
 
@@ -254,6 +257,7 @@ pub(crate) fn stash_diffs(repo: &Repository, stash_ref: &str) -> Res<StashDiffs>
             file_diffs: gitu_diff::Parser::new(&text).parse_diff().unwrap(),
             diff_type: DiffType::TreeToTree,
             text,
+            commit: None,
         })
     };
 
@@ -272,6 +276,7 @@ pub(crate) fn stash_diffs(repo: &Repository, stash_ref: &str) -> Res<StashDiffs>
             file_diffs: gitu_diff::Parser::new(&text).parse_diff().unwrap(),
             diff_type: DiffType::TreeToTree,
             text,
+            commit: None,
         })
     };
 
@@ -280,6 +285,7 @@ pub(crate) fn stash_diffs(repo: &Repository, stash_ref: &str) -> Res<StashDiffs>
             text: String::new(),
             diff_type: DiffType::TreeToTree,
             file_diffs: vec![],
+            commit: None,
         };
         return Ok(StashDiffs {
             staged: empty,
@@ -426,6 +432,95 @@ pub(crate) fn does_branch_exist(repo: &git2::Repository, name: &str) -> Res<bool
     } else {
         Err(Error::DoesBranchExist(err))
     }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct BlameLine {
+    pub commit_hash: String,
+    pub short_hash: String,
+    pub author: String,
+    pub author_time: i64,
+    pub summary: String,
+    pub line_num: u32,
+    pub orig_line_num: u32,
+    pub content: String,
+}
+
+pub(crate) fn blame(
+    repo: &Repository,
+    file_path: &str,
+    commit: Option<&str>,
+) -> Res<Vec<BlameLine>> {
+    let dir = repo.workdir().expect("Bare repos unhandled");
+
+    let mut args = vec!["blame", "--line-porcelain"];
+    let commit_owned;
+    if let Some(c) = commit {
+        commit_owned = c.to_string();
+        args.push(commit_owned.as_str());
+    }
+    args.extend_from_slice(&["--", file_path]);
+
+    let output = Command::new("git")
+        .current_dir(dir)
+        .args(&args)
+        .output()
+        .map_err(Error::GitBlame)?;
+
+    if !output.status.success() {
+        return Ok(vec![]);
+    }
+
+    let text = String::from_utf8_lossy(&output.stdout).into_owned();
+    Ok(parse_blame_porcelain(&text))
+}
+
+fn parse_blame_porcelain(text: &str) -> Vec<BlameLine> {
+    let mut lines = text.lines();
+    let mut result = Vec::new();
+
+    while let Some(header) = lines.next() {
+        let parts: Vec<&str> = header.splitn(4, ' ').collect();
+        if parts.len() < 3 || parts[0].len() < 8 {
+            continue;
+        }
+
+        let commit_hash = parts[0].to_string();
+        let short_hash = commit_hash[..8].to_string();
+        let orig_line_num: u32 = parts[1].parse().unwrap_or(0);
+        let line_num: u32 = parts[2].parse().unwrap_or(0);
+
+        let mut author = String::new();
+        let mut author_time: i64 = 0;
+        let mut summary = String::new();
+        let mut content = String::new();
+
+        for line in lines.by_ref() {
+            if let Some(rest) = line.strip_prefix('\t') {
+                content = rest.to_string();
+                break;
+            } else if let Some(rest) = line.strip_prefix("author ") {
+                author = rest.to_string();
+            } else if let Some(rest) = line.strip_prefix("author-time ") {
+                author_time = rest.parse().unwrap_or(0);
+            } else if let Some(rest) = line.strip_prefix("summary ") {
+                summary = rest.to_string();
+            }
+        }
+
+        result.push(BlameLine {
+            commit_hash,
+            short_hash,
+            author,
+            author_time,
+            summary,
+            line_num,
+            orig_line_num,
+            content,
+        });
+    }
+
+    result
 }
 
 pub(crate) fn restore_index(file: &Path) -> Command {

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -225,6 +225,43 @@ pub(crate) fn iter_syntax_highlights<'a>(
     .peekable()
 }
 
+pub(crate) fn highlight_blame_file(
+    config: &Config,
+    file_path: &str,
+    content: String,
+) -> BlameHighlights {
+    let mut highlights_iter =
+        iter_syntax_highlights(&config.style.syntax_highlight, file_path, content.clone());
+
+    let mut result = BlameHighlights {
+        spans: vec![],
+        line_index: vec![],
+    };
+
+    for (line_range, _) in line_range_iterator(&content) {
+        let start = result.spans.len();
+        collect_line_highlights(&mut highlights_iter, &line_range, &mut result.spans);
+        result.line_index.push(start..result.spans.len());
+    }
+
+    result
+}
+
+#[derive(Debug, Clone)]
+pub struct BlameHighlights {
+    spans: Vec<(Range<usize>, Style)>,
+    line_index: Vec<Range<usize>>,
+}
+
+impl BlameHighlights {
+    pub fn get_line_highlights(&self, line: usize) -> &[(Range<usize>, Style)] {
+        if line >= self.line_index.len() {
+            return &[];
+        }
+        &self.spans[self.line_index[line].clone()]
+    }
+}
+
 pub(crate) fn fill_gaps<T: Clone + Default>(
     full_range: Range<usize>,
     ranges: impl Iterator<Item = (Range<usize>, T)>,

--- a/src/item_data.rs
+++ b/src/item_data.rs
@@ -1,6 +1,6 @@
 use std::{ops::Range, path::PathBuf, rc::Rc};
 
-use crate::{Res, error::Error, git::diff::Diff};
+use crate::{Res, error::Error, git::diff::Diff, highlight::BlameHighlights};
 
 #[derive(Clone, Debug)]
 pub(crate) enum ItemData {
@@ -22,6 +22,7 @@ pub(crate) enum ItemData {
     Delta {
         diff: Rc<Diff>,
         file_i: usize,
+        commit: Option<String>,
     },
     Hunk {
         diff: Rc<Diff>,
@@ -43,6 +44,30 @@ pub(crate) enum ItemData {
     Header(SectionHeader),
     BranchStatus(String, u32, u32),
     Error(String),
+    BlameHeader {
+        commit_hash: String,
+        short_hash: String,
+        _author: String,
+        _author_time: i64,
+        summary: String,
+        file_path: String,
+        line_num: u32, // orig line in the introducing commit (for show-screen nav)
+        blamed_line_num: u32, // line number in the blamed file (for blame-view nav)
+    },
+    BlameCodeLine {
+        blame_file: Rc<BlameFile>,
+        line_i: usize,
+        line_num: u32,
+        orig_line_num: u32,
+        content: String,
+        commit_hash: String,
+        file_path: String,
+    },
+}
+
+#[derive(Debug)]
+pub(crate) struct BlameFile {
+    pub highlights: BlameHighlights,
 }
 
 impl ItemData {
@@ -72,6 +97,8 @@ impl ItemData {
                 .cloned()
                 .map(Rev::Ref)
                 .or_else(|| Some(Rev::Commit(oid.to_owned()))),
+            ItemData::BlameHeader { commit_hash, .. }
+            | ItemData::BlameCodeLine { commit_hash, .. } => Some(Rev::Commit(commit_hash.clone())),
             _ => None,
         }
     }
@@ -157,4 +184,5 @@ pub(crate) enum SectionHeader {
     StagedChanges(usize),
     UnstagedChanges(usize),
     UntrackedFiles(usize),
+    Blame(String, String),
 }

--- a/src/items.rs
+++ b/src/items.rs
@@ -9,6 +9,7 @@ use crate::item_data::Ref;
 use crate::item_data::SectionHeader;
 use git2::Oid;
 use git2::Repository;
+use ratatui::style::Style;
 use ratatui::text::Line;
 use ratatui::text::Span;
 use regex::Regex;
@@ -77,7 +78,7 @@ impl Item {
                 path.to_string_lossy().into_owned(),
                 &config.style.file_header,
             ),
-            ItemData::Delta { diff, file_i } => {
+            ItemData::Delta { diff, file_i, .. } => {
                 let file_diff = &diff.file_diffs[file_i];
 
                 let content = format!(
@@ -153,6 +154,9 @@ impl Item {
                     SectionHeader::StagedChanges(count) => format!("Staged changes ({count})"),
                     SectionHeader::UnstagedChanges(count) => format!("Unstaged changes ({count})"),
                     SectionHeader::UntrackedFiles(count) => format!("Untracked files ({count})"),
+                    SectionHeader::Blame(file, commit) => {
+                        format!("Blame {file} @ {commit}")
+                    }
                 };
 
                 Line::styled(content, &config.style.section_header)
@@ -173,6 +177,38 @@ impl Item {
                 Line::raw(content)
             }
             ItemData::Error(err) => Line::raw(err),
+            ItemData::BlameHeader {
+                short_hash,
+                summary,
+                ..
+            } => Line::from(vec![
+                Span::styled(format!("{:<8}", short_hash), &config.style.hash),
+                Span::raw(" "),
+                Span::raw(summary.clone()),
+            ]),
+            ItemData::BlameCodeLine {
+                blame_file,
+                line_i,
+                line_num,
+                content,
+                ..
+            } => {
+                let mut spans = vec![Span::styled(
+                    format!("{:>4} ", line_num),
+                    &config.style.blame.line_num,
+                )];
+
+                for (range, style) in blame_file.highlights.get_line_highlights(line_i) {
+                    if !range.is_empty() && range.end <= content.len() {
+                        spans.push(Span::styled(
+                            content[range.clone()].replace('\t', "    "),
+                            *style,
+                        ));
+                    }
+                }
+
+                Line::from(spans).style(Style::from(&config.style.blame.code_line))
+            }
         }
     }
 }
@@ -181,6 +217,7 @@ pub(crate) fn create_diff_items(
     diff: &Rc<Diff>,
     depth: usize,
     default_collapsed: bool,
+    commit: Option<String>,
 ) -> impl Iterator<Item = Item> + '_ {
     diff.file_diffs
         .iter()
@@ -193,6 +230,7 @@ pub(crate) fn create_diff_items(
                 data: ItemData::Delta {
                     diff: Rc::clone(diff),
                     file_i,
+                    commit: commit.clone(),
                 },
                 ..Default::default()
             })

--- a/src/ops/apply.rs
+++ b/src/ops/apply.rs
@@ -13,7 +13,7 @@ impl OpTrait for Apply {
     fn get_action(&self, target: &ItemData) -> Option<Action> {
         let action = match target {
             ItemData::Stash { stash_ref, .. } => apply_stash(stash_ref.clone()),
-            ItemData::Delta { diff, file_i } => apply_patch(diff.format_file_patch(*file_i)),
+            ItemData::Delta { diff, file_i, .. } => apply_patch(diff.format_file_patch(*file_i)),
             ItemData::Hunk {
                 diff,
                 file_i,

--- a/src/ops/blame.rs
+++ b/src/ops/blame.rs
@@ -1,0 +1,104 @@
+use super::OpTrait;
+use crate::{Action, app::State, error::Error, item_data::ItemData, screen};
+use std::{rc::Rc, sync::Arc};
+
+pub(crate) struct Blame;
+impl OpTrait for Blame {
+    fn get_action(&self, target: &ItemData) -> Option<Action> {
+        match target {
+            ItemData::Delta {
+                diff,
+                file_i,
+                commit,
+            } => {
+                let file_path = diff.file_diffs[*file_i]
+                    .header
+                    .new_file
+                    .fmt(&diff.text)
+                    .to_string();
+                open_blame(file_path, commit.clone(), None)
+            }
+            ItemData::Hunk {
+                diff,
+                file_i,
+                hunk_i,
+            } => {
+                let file_path = diff.file_diffs[*file_i]
+                    .header
+                    .new_file
+                    .fmt(&diff.text)
+                    .to_string();
+                let line = diff.hunk_first_changed_line_num(*file_i, *hunk_i);
+                open_blame(file_path, diff.commit.clone(), Some(line))
+            }
+            ItemData::HunkLine {
+                diff,
+                file_i,
+                hunk_i,
+                line_i,
+                line_range,
+            } => {
+                let hunk_content = diff.hunk_content(*file_i, *hunk_i);
+                let line_content = &hunk_content[line_range.clone()];
+                if line_content.starts_with('-') {
+                    return None;
+                }
+                let file_path = diff.file_diffs[*file_i]
+                    .header
+                    .new_file
+                    .fmt(&diff.text)
+                    .to_string();
+                let line = diff.hunk_line_new_file_num(*file_i, *hunk_i, *line_i);
+                open_blame(file_path, diff.commit.clone(), Some(line))
+            }
+            ItemData::BlameHeader {
+                commit_hash,
+                file_path,
+                line_num,
+                ..
+            } if !commit_hash.chars().all(|c| c == '0') => {
+                let parent = format!("{}^", commit_hash);
+                open_blame(file_path.clone(), Some(parent), Some(*line_num))
+            }
+            ItemData::BlameCodeLine {
+                commit_hash,
+                file_path,
+                orig_line_num,
+                ..
+            } if !commit_hash.chars().all(|c| c == '0') => {
+                let parent = format!("{}^", commit_hash);
+                open_blame(file_path.clone(), Some(parent), Some(*orig_line_num))
+            }
+            _ => None,
+        }
+    }
+
+    fn is_target_op(&self) -> bool {
+        true
+    }
+
+    fn display(&self, _state: &State) -> String {
+        "Blame".into()
+    }
+}
+
+fn open_blame(
+    file_path: String,
+    commit: Option<String>,
+    target_line: Option<u32>,
+) -> Option<Action> {
+    Some(Rc::new(move |app, term| {
+        app.state.screens.push(
+            screen::blame::create(
+                Arc::clone(&app.state.config),
+                Rc::clone(&app.state.repo),
+                term.size().map_err(Error::Term)?,
+                file_path.clone(),
+                commit.clone(),
+                target_line,
+            )
+            .expect("Couldn't create blame screen"),
+        );
+        Ok(())
+    }))
+}

--- a/src/ops/discard.rs
+++ b/src/ops/discard.rs
@@ -18,7 +18,7 @@ impl OpTrait for Discard {
                 ..
             } => discard_branch(branch.clone()),
             ItemData::Untracked(file) => clean_file(file.clone()),
-            ItemData::Delta { diff, file_i } => {
+            ItemData::Delta { diff, file_i, .. } => {
                 let patch = diff.format_file_patch(*file_i);
                 match diff.diff_type {
                     DiffType::WorkdirToIndex => reverse_worktree(patch),

--- a/src/ops/editor.rs
+++ b/src/ops/editor.rs
@@ -187,7 +187,7 @@ pub(crate) struct MoveDownLine;
 impl OpTrait for MoveDownLine {
     fn get_action(&self, _target: &ItemData) -> Option<Action> {
         Some(Rc::new(|app, _term| {
-            app.screen_mut().select_next(NavMode::IncludeHunkLines);
+            app.screen_mut().select_next(NavMode::IncludeSubLines);
             Ok(())
         }))
     }
@@ -201,7 +201,7 @@ pub(crate) struct MoveUpLine;
 impl OpTrait for MoveUpLine {
     fn get_action(&self, _target: &ItemData) -> Option<Action> {
         Some(Rc::new(|app, _term| {
-            app.screen_mut().select_previous(NavMode::IncludeHunkLines);
+            app.screen_mut().select_previous(NavMode::IncludeSubLines);
             Ok(())
         }))
     }

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -10,6 +10,7 @@ use crate::{
 use std::{fmt::Display, rc::Rc};
 
 pub(crate) mod apply;
+pub(crate) mod blame;
 pub(crate) mod branch;
 pub(crate) mod cherry_pick;
 pub(crate) mod commit;
@@ -110,6 +111,7 @@ pub(crate) enum Op {
     Apply,
     Reverse,
     CopyHash,
+    Blame,
 
     ToggleSection,
     MoveUp,
@@ -203,6 +205,7 @@ impl Op {
             Op::Apply => Box::new(apply::Apply),
             Op::Reverse => Box::new(reverse::Reverse),
             Op::CopyHash => Box::new(copy_hash::CopyHash),
+            Op::Blame => Box::new(blame::Blame),
 
             Op::AddRemote => Box::new(remote::AddRemote),
             Op::RemoveRemote => Box::new(remote::RemoveRemote),

--- a/src/ops/reverse.rs
+++ b/src/ops/reverse.rs
@@ -12,7 +12,7 @@ pub(crate) struct Reverse;
 impl OpTrait for Reverse {
     fn get_action(&self, target: &ItemData) -> Option<Action> {
         let action = match target {
-            ItemData::Delta { diff, file_i } => reverse_patch(diff.format_file_patch(*file_i)),
+            ItemData::Delta { diff, file_i, .. } => reverse_patch(diff.format_file_patch(*file_i)),
             ItemData::Hunk {
                 diff,
                 file_i,

--- a/src/ops/show.rs
+++ b/src/ops/show.rs
@@ -57,6 +57,20 @@ impl OpTrait for Show {
                     Some(diff.file_line_of_first_diff(*file_i, *hunk_i) as u32),
                 )
             }
+            ItemData::HunkLine {
+                diff,
+                file_i,
+                hunk_i,
+                line_i,
+                ..
+            } => {
+                let file_path = &diff.file_diffs[*file_i].header.new_file;
+                let path: &str = &file_path.fmt(&diff.text);
+                editor(
+                    Path::new(path),
+                    Some(diff.hunk_line_new_file_num(*file_i, *hunk_i, *line_i)),
+                )
+            }
             ItemData::Stash { stash_ref, .. } => goto_show_stash_screen(stash_ref.clone()),
             _ => None,
         }

--- a/src/ops/show.rs
+++ b/src/ops/show.rs
@@ -21,9 +21,26 @@ impl OpTrait for Show {
             | ItemData::Reference {
                 kind: Ref::Head(oid),
                 ..
-            } => goto_show_screen(oid.clone()),
+            } => goto_show_screen(oid.clone(), None),
+            ItemData::BlameHeader {
+                commit_hash,
+                file_path,
+                line_num,
+                ..
+            } if !is_null_oid(commit_hash) => {
+                goto_show_screen(commit_hash.clone(), Some((file_path.clone(), *line_num)))
+            }
+            ItemData::BlameCodeLine {
+                commit_hash,
+                file_path,
+                orig_line_num,
+                ..
+            } if !is_null_oid(commit_hash) => goto_show_screen(
+                commit_hash.clone(),
+                Some((file_path.clone(), *orig_line_num)),
+            ),
             ItemData::Untracked(u) => editor(u.as_path(), None),
-            ItemData::Delta { diff, file_i } => {
+            ItemData::Delta { diff, file_i, .. } => {
                 let file_path = &diff.file_diffs[*file_i].header.new_file;
                 let path: &str = &file_path.fmt(&diff.text);
                 editor(Path::new(path), None)
@@ -53,7 +70,7 @@ impl OpTrait for Show {
     }
 }
 
-fn goto_show_screen(r: String) -> Option<Action> {
+fn goto_show_screen(r: String, target: Option<(String, u32)>) -> Option<Action> {
     Some(Rc::new(move |app, term| {
         app.state.screens.push(
             screen::show::create(
@@ -61,6 +78,7 @@ fn goto_show_screen(r: String) -> Option<Action> {
                 Rc::clone(&app.state.repo),
                 term.size().map_err(Error::Term)?,
                 r.clone(),
+                target.clone(),
             )
             .expect("Couldn't create screen"),
         );
@@ -81,6 +99,10 @@ fn goto_show_stash_screen(stash_ref: String) -> Option<Action> {
         );
         Ok(())
     }))
+}
+
+fn is_null_oid(hash: &str) -> bool {
+    hash.chars().all(|c| c == '0')
 }
 
 pub(crate) const EDITOR_VARS: [&str; 4] = ["GITU_SHOW_EDITOR", "VISUAL", "EDITOR", "GIT_EDITOR"];

--- a/src/ops/stage.rs
+++ b/src/ops/stage.rs
@@ -16,7 +16,7 @@ impl OpTrait for Stage {
             ItemData::AllUnstaged(_) => stage_unstaged(),
             ItemData::AllUntracked(untracked) => stage_untracked(untracked.clone()),
             ItemData::Untracked(u) => stage_file(u.into()),
-            ItemData::Delta { diff, file_i } => {
+            ItemData::Delta { diff, file_i, .. } => {
                 let diff_header = &diff.file_diffs[*file_i].header;
                 let file_path = match diff_header.status {
                     Status::Deleted => &diff_header.old_file,

--- a/src/ops/unstage.rs
+++ b/src/ops/unstage.rs
@@ -14,7 +14,7 @@ impl OpTrait for Unstage {
     fn get_action(&self, target: &ItemData) -> Option<Action> {
         let action = match target {
             ItemData::AllStaged(_) => unstage_staged(),
-            ItemData::Delta { diff, file_i } => {
+            ItemData::Delta { diff, file_i, .. } => {
                 let diff_header = &diff.file_diffs[*file_i].header;
                 let file_path = match diff_header.status {
                     Status::Deleted => &diff_header.old_file,

--- a/src/screen/blame.rs
+++ b/src/screen/blame.rs
@@ -1,0 +1,111 @@
+use std::{rc::Rc, sync::Arc};
+
+use crate::{
+    Res,
+    config::Config,
+    git, highlight,
+    item_data::{BlameFile, ItemData, SectionHeader},
+    items::{Item, hash},
+};
+use git2::Repository;
+use ratatui::layout::Size;
+
+use super::Screen;
+
+pub(crate) fn create(
+    config: Arc<Config>,
+    repo: Rc<Repository>,
+    size: Size,
+    file_path: String,
+    commit: Option<String>,
+    target_line: Option<u32>,
+) -> Res<Screen> {
+    let mut screen = Screen::new(
+        Arc::clone(&config),
+        size,
+        Box::new(move || {
+            let commit_display = commit.as_deref().unwrap_or("HEAD").to_string();
+            let blame_lines = git::blame(repo.as_ref(), &file_path, commit.as_deref())?;
+
+            let full_content = blame_lines
+                .iter()
+                .map(|l| l.content.as_str())
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            let highlights = highlight::highlight_blame_file(&config, &file_path, full_content);
+
+            let blame_file = Rc::new(BlameFile { highlights });
+
+            let header = Item {
+                id: hash(("blame_header", file_path.as_str(), commit_display.as_str())),
+                depth: 0,
+                unselectable: true,
+                data: ItemData::Header(SectionHeader::Blame(file_path.clone(), commit_display)),
+                ..Default::default()
+            };
+
+            let entries = blame_lines
+                .into_iter()
+                .enumerate()
+                .scan(None::<String>, |prev_hash, (line_i, line)| {
+                    let is_new_chunk = prev_hash.as_deref() != Some(line.commit_hash.as_str());
+                    *prev_hash = Some(line.commit_hash.clone());
+                    Some((line_i, line, is_new_chunk))
+                })
+                .flat_map(|(line_i, line, is_new_chunk)| {
+                    let mut items = Vec::new();
+
+                    if is_new_chunk {
+                        items.push(Item {
+                            id: hash(("blame_chunk", line.commit_hash.as_str(), line.line_num)),
+                            depth: 0,
+                            data: ItemData::BlameHeader {
+                                commit_hash: line.commit_hash.clone(),
+                                short_hash: line.short_hash.clone(),
+                                _author: line.author.clone(),
+                                _author_time: line.author_time,
+                                summary: line.summary.clone(),
+                                file_path: file_path.clone(),
+                                line_num: line.orig_line_num,
+                                blamed_line_num: line.line_num,
+                            },
+                            ..Default::default()
+                        });
+                    }
+
+                    items.push(Item {
+                        id: hash(("blame_code", line.commit_hash.as_str(), line.line_num)),
+                        depth: 0,
+                        data: ItemData::BlameCodeLine {
+                            blame_file: Rc::clone(&blame_file),
+                            line_i,
+                            line_num: line.line_num,
+                            orig_line_num: line.orig_line_num,
+                            content: line.content,
+                            commit_hash: line.commit_hash,
+                            file_path: file_path.clone(),
+                        },
+                        ..Default::default()
+                    });
+
+                    items
+                });
+
+            Ok(std::iter::once(header).chain(entries).collect())
+        }),
+    )?;
+
+    if let Some(line) = target_line
+        && !screen.select_matching(
+            |data| matches!(data, ItemData::BlameCodeLine { line_num, .. } if *line_num == line),
+        )
+    {
+        screen.select_last_matching(|data| {
+            matches!(data, ItemData::BlameHeader { blamed_line_num, .. }
+                if *blamed_line_num <= line)
+        });
+    }
+
+    Ok(screen)
+}

--- a/src/screen/mod.rs
+++ b/src/screen/mod.rs
@@ -12,6 +12,7 @@ use std::borrow::Cow;
 use std::collections::HashSet;
 use std::sync::Arc;
 
+pub(crate) mod blame;
 pub(crate) mod log;
 pub(crate) mod show;
 pub(crate) mod show_refs;
@@ -24,7 +25,7 @@ const BOTTOM_CONTEXT_LINES: usize = 2;
 pub(crate) enum NavMode {
     Normal,
     Siblings { depth: usize },
-    IncludeHunkLines,
+    IncludeSubLines,
 }
 
 pub(crate) struct Screen {
@@ -145,14 +146,16 @@ impl Screen {
         let item = self.at_line(line_i);
         match nav_mode {
             NavMode::Normal => {
-                let is_hunk_line = matches!(item.data, ItemData::HunkLine { .. });
-
-                !item.unselectable && !is_hunk_line
+                let is_sub_line = matches!(
+                    item.data,
+                    ItemData::HunkLine { .. } | ItemData::BlameCodeLine { .. }
+                );
+                !item.unselectable && !is_sub_line
             }
             NavMode::Siblings { depth } => {
                 !item.unselectable && item.data.is_section() && item.depth <= depth
             }
-            NavMode::IncludeHunkLines => !item.unselectable,
+            NavMode::IncludeSubLines => !item.unselectable,
         }
     }
 
@@ -246,7 +249,7 @@ impl Screen {
         }
 
         match self.get_selected_item().data {
-            ItemData::HunkLine { .. } => NavMode::IncludeHunkLines,
+            ItemData::HunkLine { .. } | ItemData::BlameCodeLine { .. } => NavMode::IncludeSubLines,
             _ => NavMode::Normal,
         }
     }
@@ -331,12 +334,46 @@ impl Screen {
         &self.items[self.line_index[self.cursor]]
     }
 
+    pub(crate) fn select_matching<F: Fn(&ItemData) -> bool>(&mut self, predicate: F) -> bool {
+        if let Some(line_i) = (0..self.line_index.len()).find(|&line_i| {
+            !self.at_line(line_i).unselectable && predicate(&self.at_line(line_i).data)
+        }) {
+            self.cursor = line_i;
+            let half_screen = self.size.height as usize / 2;
+            if self.cursor >= half_screen {
+                self.scroll = self.cursor - half_screen;
+            }
+            self.scroll_fit_end();
+            self.scroll_fit_start();
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn select_last_matching<F: Fn(&ItemData) -> bool>(&mut self, predicate: F) -> bool {
+        if let Some(line_i) = (0..self.line_index.len()).rev().find(|&line_i| {
+            !self.at_line(line_i).unselectable && predicate(&self.at_line(line_i).data)
+        }) {
+            self.cursor = line_i;
+            let half_screen = self.size.height as usize / 2;
+            if self.cursor >= half_screen {
+                self.scroll = self.cursor - half_screen;
+            } else {
+                self.scroll_fit_start();
+            }
+            true
+        } else {
+            false
+        }
+    }
+
     pub(crate) fn is_valid_screen_line(&self, screen_line: usize) -> bool {
         let target_line_i = screen_line + self.scroll;
         if self.line_index.is_empty() || target_line_i >= self.line_index.len() {
             return false;
         }
-        self.nav_filter(target_line_i, NavMode::IncludeHunkLines)
+        self.nav_filter(target_line_i, NavMode::IncludeSubLines)
     }
 
     fn line_views(&'_ self, area: Size) -> impl Iterator<Item = LineView<'_>> {

--- a/src/screen/show.rs
+++ b/src/screen/show.rs
@@ -17,8 +17,9 @@ pub(crate) fn create(
     repo: Rc<Repository>,
     size: Size,
     reference: String,
+    target: Option<(String, u32)>,
 ) -> Res<Screen> {
-    Screen::new(
+    let mut screen = Screen::new(
         Arc::clone(&config),
         size,
         Box::new(move || {
@@ -40,8 +41,43 @@ pub(crate) fn create(
                 ..Default::default()
             }))
             .chain([items::blank_line()])
-            .chain(items::create_diff_items(&Rc::new(show), 0, false))
+            .chain(items::create_diff_items(
+                &Rc::new(show),
+                0,
+                false,
+                Some(commit.hash.clone()),
+            ))
             .collect())
         }),
-    )
+    )?;
+
+    if let Some((file, line_num)) = target {
+        let found = screen.select_matching(|data| {
+            if let ItemData::HunkLine {
+                diff,
+                file_i,
+                hunk_i,
+                line_i,
+                line_range,
+            } = data
+            {
+                if diff.file_diffs[*file_i].header.new_file.fmt(&diff.text) != file {
+                    return false;
+                }
+                let line = &diff.hunk_content(*file_i, *hunk_i)[line_range.clone()];
+                !line.starts_with('-')
+                    && diff.hunk_line_new_file_num(*file_i, *hunk_i, *line_i) == line_num
+            } else {
+                false
+            }
+        });
+        if !found {
+            screen.select_matching(|data| {
+                matches!(data, ItemData::Delta { diff, file_i, .. }
+                    if diff.file_diffs[*file_i].header.new_file.fmt(&diff.text) == file)
+            });
+        }
+    }
+
+    Ok(screen)
 }

--- a/src/screen/show_stash.rs
+++ b/src/screen/show_stash.rs
@@ -57,7 +57,7 @@ pub(crate) fn create(
                         ..Default::default()
                     },
                 ]);
-                out.extend(items::create_diff_items(&diff, 1, false));
+                out.extend(items::create_diff_items(&diff, 1, false, None));
             };
 
             if !staged.file_diffs.is_empty() {

--- a/src/screen/status.rs
+++ b/src/screen/status.rs
@@ -197,7 +197,7 @@ fn create_status_section_items<'a>(
         ]
     }
     .into_iter()
-    .chain(items::create_diff_items(diff, 1, true))
+    .chain(items::create_diff_items(diff, 1, true, None))
 }
 
 fn create_stash_list_section_items<'a>(

--- a/src/tests/blame.rs
+++ b/src/tests/blame.rs
@@ -1,0 +1,62 @@
+use super::*;
+
+fn setup(ctx: TestContext) -> TestContext {
+    commit(
+        &ctx.dir,
+        "file",
+        "unchanged-top\noriginal\nunchanged-bottom\n",
+    );
+    commit(
+        &ctx.dir,
+        "file",
+        "unchanged-top\nSELECT-THIS-LINE\nunchanged-bottom\n",
+    );
+    ctx
+}
+
+fn setup_shifted(ctx: TestContext) -> TestContext {
+    // commit A: file with target line at position 2
+    commit(&ctx.dir, "file", "top\nSELECT-THIS-LINE\nbottom\n");
+    // commit B: prepends 5 lines, pushing SELECT-THIS-LINE to position 7 in HEAD
+    commit(
+        &ctx.dir,
+        "file",
+        "added1\nadded2\nadded3\nadded4\nadded5\ntop\nSELECT-THIS-LINE\nbottom\n",
+    );
+    ctx
+}
+
+#[test]
+fn blame_from_hunk() {
+    snapshot!(setup(setup_clone!()), "ll<enter>B");
+}
+
+#[test]
+fn blame_navigate_code_line() {
+    snapshot!(setup(setup_clone!()), "ll<enter>B<ctrl+j>");
+}
+
+#[test]
+fn blame_enter_on_header() {
+    snapshot!(setup(setup_clone!()), "ll<enter>Bk<enter>");
+}
+
+#[test]
+fn blame_enter_on_code_line() {
+    snapshot!(setup(setup_clone!()), "ll<enter>B<enter>");
+}
+
+#[test]
+fn blame_re_blame_from_header() {
+    snapshot!(setup(setup_clone!()), "ll<enter>BB");
+}
+
+#[test]
+fn blame_re_blame_from_code_line() {
+    snapshot!(setup(setup_clone!()), "ll<enter>BB");
+}
+
+#[test]
+fn blame_from_hunk_shifted_lines() {
+    snapshot!(setup_shifted(setup_clone!()), "llj<enter>B");
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -14,6 +14,7 @@ use std::fs;
 #[macro_use]
 mod helpers;
 mod arg;
+mod blame;
 mod branch;
 mod cherry_pick;
 mod commit;

--- a/src/tests/snapshots/gitu__tests__blame__blame_enter_on_code_line.snap
+++ b/src/tests/snapshots/gitu__tests__blame__blame_enter_on_code_line.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/blame.rs
+expression: ctx.redact_buffer()
+---
+ Date:   Fri, 16 Feb 2024 11:11:00 +0100                                        |
+                                                                                |
+     modify file                                                                |
+                                                                                |
+     Commit body goes here                                                      |
+                                                                                |
+ modified   file                                                                |
+ @@ -1,3 +1,3 @@                                                                |
+  unchanged-top                                                                 |
+ -original                                                                      |
+▌+SELECT-THIS-LINE                                                              |
+  unchanged-bottom                                                              |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: 53ab6c4805700159

--- a/src/tests/snapshots/gitu__tests__blame__blame_enter_on_header.snap
+++ b/src/tests/snapshots/gitu__tests__blame__blame_enter_on_header.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/blame.rs
+expression: ctx.redact_buffer()
+---
+ Date:   Fri, 16 Feb 2024 11:11:00 +0100                                        |
+                                                                                |
+     modify file                                                                |
+                                                                                |
+     Commit body goes here                                                      |
+                                                                                |
+ modified   file                                                                |
+ @@ -1,3 +1,3 @@                                                                |
+  unchanged-top                                                                 |
+ -original                                                                      |
+▌+SELECT-THIS-LINE                                                              |
+  unchanged-bottom                                                              |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: 53ab6c4805700159

--- a/src/tests/snapshots/gitu__tests__blame__blame_from_hunk.snap
+++ b/src/tests/snapshots/gitu__tests__blame__blame_from_hunk.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/blame.rs
+expression: ctx.redact_buffer()
+---
+ Blame file @ dc61526641c542a66eef0574499da9b6f12a5764                          |
+ 1fcc61bc add file                                                              |
+    1 unchanged-top                                                             |
+ dc615266 modify file                                                           |
+▌   2 SELECT-THIS-LINE                                                          |
+ 1fcc61bc add file                                                              |
+    3 unchanged-botto                                                           |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: 8f174603e5263fc7

--- a/src/tests/snapshots/gitu__tests__blame__blame_from_hunk_shifted_lines.snap
+++ b/src/tests/snapshots/gitu__tests__blame__blame_from_hunk_shifted_lines.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/blame.rs
+expression: ctx.redact_buffer()
+---
+ Blame file @ fa5e4bd731a775eec7d161bd5e133baca888379d                          |
+ fa5e4bd7 add file                                                              |
+▌   1 top                                                                       |
+    2 SELECT-THIS-LINE                                                          |
+    3 botto                                                                     |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: 5775387cf04ec79

--- a/src/tests/snapshots/gitu__tests__blame__blame_navigate_code_line.snap
+++ b/src/tests/snapshots/gitu__tests__blame__blame_navigate_code_line.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/blame.rs
+expression: ctx.redact_buffer()
+---
+ Blame file @ dc61526641c542a66eef0574499da9b6f12a5764                          |
+ 1fcc61bc add file                                                              |
+    1 unchanged-top                                                             |
+ dc615266 modify file                                                           |
+    2 SELECT-THIS-LINE                                                          |
+▌1fcc61bc add file                                                              |
+    3 unchanged-botto                                                           |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: ddb1fc6e53dc63a8

--- a/src/tests/snapshots/gitu__tests__blame__blame_re_blame_from_code_line.snap
+++ b/src/tests/snapshots/gitu__tests__blame__blame_re_blame_from_code_line.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/blame.rs
+expression: ctx.redact_buffer()
+---
+ Blame file @ dc61526641c542a66eef0574499da9b6f12a5764^                         |
+ 1fcc61bc add file                                                              |
+    1 unchanged-top                                                             |
+▌   2 original                                                                  |
+    3 unchanged-botto                                                           |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: f6ac29ed54b120db

--- a/src/tests/snapshots/gitu__tests__blame__blame_re_blame_from_header.snap
+++ b/src/tests/snapshots/gitu__tests__blame__blame_re_blame_from_header.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/blame.rs
+expression: ctx.redact_buffer()
+---
+ Blame file @ dc61526641c542a66eef0574499da9b6f12a5764^                         |
+ 1fcc61bc add file                                                              |
+    1 unchanged-top                                                             |
+▌   2 original                                                                  |
+    3 unchanged-botto                                                           |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: f6ac29ed54b120db


### PR DESCRIPTION

<img width="1130" height="454" alt="image" src="https://github.com/user-attachments/assets/a41dfe89-90ce-40ad-b426-26a387b9fee7" />


TODO
- [ ] Will want to show auther/date right-aligned
- [ ] *enter* on a commit in the blame-view should open that commit at that line
- [ ] Blaming something in a commit should blame from that version
- [ ] Blaming a hunk or line within a hunk should also be possible


## Checklist
- [ ] The modified code has some test-coverage (where applicable).
- [ ] `make test` is passing (this is what CI runs).
- [ ] New *unreleased* features/fixes/styling and performance improvements are documented via git: `feat:` / `fix:` / `style:` / `perf:`. Or e.g. `perf(highlighting):`.
      See [https://github.com/altsem/gitu/blob/master/docs/dev-tooling.md](https://github.com/altsem/gitu/blob/master/docs/dev-tooling.md)
