### PR TITLE
fix(log): avoid panic when showing log of a branch with no commits

### DIFF
--- a/src/screen/mod.rs
+++ b/src/screen/mod.rs
@@ -234,6 +234,14 @@ impl Screen {
     }
 
     fn update_cursor(&mut self, nav_mode: NavMode) {
+        // Nothing is selectable (e.g. the log of a branch with no commits).
+        // Reset the cursor to a valid sentinel rather than positioning it,
+        // which would index into an empty `line_index` and panic (#262).
+        if self.line_index.is_empty() {
+            self.cursor = 0;
+            return;
+        }
+
         self.clamp_cursor();
         if self.is_cursor_off_screen() {
             self.move_cursor_to_screen_center();

--- a/src/tests/log.rs
+++ b/src/tests/log.rs
@@ -76,3 +76,18 @@ fn log_other_input() {
 fn log_other_invalid() {
     snapshot!(setup(setup_clone!()), "lo <enter>");
 }
+
+#[test]
+fn log_empty_branch() {
+    // Regression for #262: showing the log of a branch with no commits used to
+    // panic ("index out of bounds") because the log screen had no items but the
+    // cursor still indexed into it.
+    let mut ctx = setup_clone!();
+    run(&ctx.dir, &["rm", "-rf", ".git"]);
+    run(&ctx.dir, &["rm", "initial-file"]);
+    run(&ctx.dir, &["git", "init", "--initial-branch=main"]);
+
+    let mut app = ctx.init_app();
+    ctx.update(&mut app, keys("ll"));
+    insta::assert_snapshot!(ctx.redact_buffer());
+}

--- a/src/tests/snapshots/gitu__tests__log__log_empty_branch.snap
+++ b/src/tests/snapshots/gitu__tests__log__log_empty_branch.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/log.rs
+expression: ctx.redact_buffer()
+---
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+                                                                                |
+styles_hash: 355101d0bd329837


### PR DESCRIPTION
## Problem

Opening the log of a branch with no commits panics (fixes #262):

```
mkdir example && cd example && git init
gitu      # press `l l` to show the log of the current branch
```

```
panicked at src/screen/mod.rs:99: index out of bounds: the len is 0 but the index is 0
```

## Root cause

The log screen for a branch with no commits has no items, so `line_index` is empty. But `Screen::new` → `update()` → `update_cursor()` still tries to position the cursor: `move_from_unselectable` calls `nav_filter(self.cursor)` → `at_line(0)`, which does `&self.items[self.line_index[0]]` and panics on the empty `line_index`.

## Fix

Guard `update_cursor` to reset the cursor when nothing is selectable, instead of positioning it into an empty `line_index`. This matches the existing empty-checks the other cursor/scroll helpers already use (`scroll_fit_start`, `scroll_fit_end`, `move_cursor_to_screen_line`).

I kept the fix to the single chokepoint on the panic path rather than changing `get_selected_item()` / `at_line()` to return `Option`, since `get_selected_item()` has ~12 call sites across the crate — that would be a large ripple for this bug.

## Test

Added `log_empty_branch` in `src/tests/log.rs` (same empty-repo setup as the existing `fresh_init` test, then `l l`). Before the fix it panics; after, it renders the empty log. The snapshot is blank because a branch with no commits has nothing to show — the test's purpose is that a regression would panic before reaching the assertion.

`make test` passes locally (`cargo insta test --unreferenced reject`, `cargo clippy -- -Dwarnings`, `cargo fmt --check`, `cargo bench --no-run`); full suite is green.
