### PR TITLE
fix: git diff filename parsing when filenames contain spaces

### DIFF
--- a/src/gitu_diff.rs
+++ b/src/gitu_diff.rs
@@ -354,11 +354,11 @@ impl<'a> Parser<'a> {
         }
 
         if self.consume("--- ").is_ok() {
-            old_file = self.diff_header_path(Self::newline_or_eof)?;
-            self.newline_or_eof()?;
+            old_file = self.diff_header_path(Self::newline_or_tab_or_eof)?;
+            self.consume_until_after(Self::newline_or_eof)?;
             self.consume("+++ ")?;
-            new_file = self.diff_header_path(Self::newline_or_eof)?;
-            self.newline_or_eof()?;
+            new_file = self.diff_header_path(Self::newline_or_tab_or_eof)?;
+            self.consume_until_after(Self::newline_or_eof)?;
         }
 
         Ok(DiffHeader {
@@ -665,6 +665,18 @@ impl<'a> Parser<'a> {
         })
     }
 
+    fn newline_or_tab_or_eof(&mut self) -> ThinResult<Range<usize>> {
+        log::trace!("Parser::newline_or_tab_or_eof\n{:?}", self);
+        self.newline()
+            .or_else(|_| self.tab())
+            .or_else(|_| self.eof())
+            .map_err(|_| {
+                array_vec![ThinParseError {
+                    expected: "<newline or tab or eof>",
+                }]
+            })
+    }
+
     fn newline(&mut self) -> ThinResult<Range<usize>> {
         log::trace!("Parser::newline\n{:?}", self);
         self.consume("\r\n")
@@ -674,6 +686,12 @@ impl<'a> Parser<'a> {
                     expected: "<newline>",
                 }]
             })
+    }
+
+    fn tab(&mut self) -> ThinResult<Range<usize>> {
+        log::trace!("Parser::tab\n{:?}", self);
+        self.consume("\t")
+            .map_err(|_| array_vec![ThinParseError { expected: "<tab>" }])
     }
 
     fn ascii_whitespace(&mut self) -> ThinResult<Range<usize>> {


### PR DESCRIPTION
## Checklist
- [ ] The modified code has some test-coverage (where applicable).
- [x] `make test` is passing (this is what CI runs).
- [x] New *unreleased* features/fixes/styling and performance improvements are documented via git: `feat:` / `fix:` / `style:` / `perf:`. Or e.g. `perf(highlighting):`.
      See [https://github.com/altsem/gitu/blob/master/docs/dev-tooling.md](https://github.com/altsem/gitu/blob/master/docs/dev-tooling.md)

fixes #499 

It seems git adds a tab character behind filenames with spaces in them to clearly differentiate what is still part of the filename, and what is the delimiter for metadata (even when not printing any metadata). Not an issue when the filenames get quoted, but as far as I can tell, they don't by default. This resulted in the `git add` command including that tab character, which caused an error.

I simply added a new `newline_or_tab_or_eof` delimiter that is now used instead. I haven't looked into the testing setup, so I didn't write any tests for this.

During debugging, I also noticed that the `fmt::Debug` implementation on the Parser often fails on the `log::trace!` call inside `newline_or_eof`. I think it's because `line_end` is a byte index for the string slice `self.input[line_start..]`, not for the entire string. So one would probably need something like:
```rust
        let line_end = line_start + self.input[line_start..]
            .find('\n')
            .unwrap_or(self.input.len());
```
However, it still panicked because `cursor` sometimes didn't land on a proper unicode byte. I guess there is more wrong here, so I left it out of this PR.